### PR TITLE
complete-word does not complete.

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -230,7 +230,13 @@ _zsh_highlight-install() {
           ;;
         .*)
           clean_event=$event[2,${#event}] # Remove the leading dot in the event name
-          eval "$clean_event() { builtin zle $event && _zsh_highlight-zle-buffer } ; zle -N $clean_event"
+          case ${widgets[$clean_event]-} in
+            (completion|user):*)
+              ;;
+            *)
+              eval "$clean_event() { builtin zle $event && _zsh_highlight-zle-buffer } ; zle -N $clean_event"
+              ;;
+          esac
           ;;
         *)
           ;;


### PR DESCRIPTION
For example,

```
% bindkey "^I" complete-word
% bi<TAB>
```

does not work as expected. This includes `list-choices` and maybe some more.

I tackle this problem and make a series of patches which replaces the
clauses after the '# Bind all ZLE events from zle -la to highlighting
function.'.

This is too big for me to descibe its intentions at once in the squashed
patch form, so I split the commits in smaller chunks.

Please take a look some time.

<pre>
Takeshi Banse (3):
  Make this clause function and call it afterward.
  Recreate the completion widget with its own function.
  Carefully rebind the $clean_event.

 zsh-syntax-highlighting.zsh |   50 ++++++++++++++++++++++++++----------------
 1 files changed, 31 insertions(+), 19 deletions(-)
</pre>
