### PR TITLE
Handle dirs/files with spaces in their name

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ This must be done **after** the script is sourced, otherwise your styles will be
  * [Takeshi Banse](https://github.com/hchbaw)
  * [Sorin Ionescu](https://github.com/SpookyET)
  * [Clayton Parker](https://github.com/claytron)
+ * [Arlen Cuss](https://github.com/celtic)

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -74,10 +74,10 @@ zle_highlight=(
 
 # Check if the argument is a path.
 _zsh_check-path() {
-  [[ -z $arg ]] && return 1
-  [[ -e $arg ]] && return 0
-  [[ ! -e ${arg:h} ]] && return 1
-  [[ ${#BUFFER} == $end_pos && -n $(print $arg*(N)) ]] && return 0
+  [[ -z ${(Q)arg} ]] && return 1
+  [[ -e ${(Q)arg} ]] && return 0
+  [[ ! -e ${(Q)arg:h} ]] && return 1
+  [[ ${#BUFFER} == $end_pos && -n $(print ${(Q)arg}*(N)) ]] && return 0
   return 1
 }
 


### PR DESCRIPTION
Hey there!

I've just added a small change to _zsh_check-path() so that files and directories with names with spaces in them are correctly detected as extant/non-extant.

Cheers,
Arlen
