### PR TITLE
Do nothing if pending

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -52,6 +52,10 @@ typeset -a zsh_highlight_predicates; zsh_highlight_predicates=()
 typeset -a zsh_highlight_caches; zsh_highlight_caches=()
 
 _zsh_highlight-zle-buffer() {
+  if (( PENDING )); then
+    return
+  fi
+
   local ret=$?
   {
     local -a funinds


### PR DESCRIPTION
zsh-syntax-highlighting call highlight functions at every inputs.
It's cause noticeable slowdown when long string is pasted from clipboard.

To avoid that, this commit make zsh-syntax-highlighting do nothing when PENDING inputs exists.
