### PR TITLE
Error: "unrecognized modifier 'A'" on startup for zsh 4.3.9 on OSX

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -125,7 +125,7 @@ zmodload zsh/zleparameter 2>/dev/null || {
 }
 
 # Resolve highlighters directory location.
-highlighters_dir="${ZSH_HIGHLIGHT_HIGHLIGHTERS_DIR:-${${(%):-%N}:A:h}/highlighters}"
+highlighters_dir=`dirname $0`/highlighters
 [[ -d $highlighters_dir ]] || {
   echo "zsh-syntax-highlighting: highlighters directory '$highlighters_dir' not found, exiting." >&2
   return -1


### PR DESCRIPTION
The attached patch fixes and issue I hit on zsh 4.3.9 on OSX (a listed supported version), I'm not actually quite sure what the 'A' flag does, but I think the pull request is a little easier to understand what's going on.

I get this error on 4.3.9 on OSX when starting up after sourcing the zsh-syntax-highlight.zsh file in my .zshrc:

```
/Users/tnaleid/Documents/workspace/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh:128: unrecognized modifier `A'
```

The offending line of code is:

```
highlighters_dir="${ZSH_HIGHLIGHT_HIGHLIGHTERS_DIR:-${${(%):-%N}:A:h}/highlighters}"
```

If I change it to this, it works:

```
highlighters_dir=`dirname $0`/highlighters
```
