### PR TITLE
Add ` || true ' to last line of init script to guarantee zero exit code when sourcing multiple times

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -203,4 +203,4 @@ _zsh_highlight_load_highlighters "${ZSH_HIGHLIGHT_HIGHLIGHTERS_DIR:-${0:h}/highl
 }
 
 # Initialize the array of active highlighters if needed.
-[[ $#ZSH_HIGHLIGHT_HIGHLIGHTERS -eq 0 ]] && ZSH_HIGHLIGHT_HIGHLIGHTERS=(main)
+[[ $#ZSH_HIGHLIGHT_HIGHLIGHTERS -eq 0 ]] && ZSH_HIGHLIGHT_HIGHLIGHTERS=(main) || true


### PR DESCRIPTION
When sourcing the script multiple times, the test at the end of `zsh-syntax-highlighting.zsh` returns false and the script returns an exit code of `1`.
`%>  /bin/zsh -fl
% source ~/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
% echo $?
0
% source ~/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
% echo $?
1`
I have simply added `|| true` to avoid this cosmetic issue.
