### PR TITLE
make _zsh_highlight nounset-able

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -49,7 +49,7 @@ _zsh_highlight()
 
   # Do not highlight if there are more than 300 chars in the buffer. It's most
   # likely a pasted command or a huge list of files in that case..
-  [[ -n $ZSH_HIGHLIGHT_MAXLENGTH ]] && [[ $#BUFFER -gt $ZSH_HIGHLIGHT_MAXLENGTH ]] && return $ret
+  [[ -n ${ZSH_HIGHLIGHT_MAXLENGTH:-} ]] && [[ $#BUFFER -gt $ZSH_HIGHLIGHT_MAXLENGTH ]] && return $ret
 
   # Do not highlight if there are pending inputs (copy/paste).
   [[ $PENDING -gt 0 ]] && return $ret
@@ -69,7 +69,8 @@ _zsh_highlight()
 
         # Remove what was stored in its cache from region_highlight.
         cache_place="_zsh_highlight_${highlighter}_highlighter_cache"
-        [[ ${#${(P)cache_place}} -gt 0 ]] && region_highlight=(${region_highlight:#(${(P~j.|.)cache_place})})
+        typeset -ga ${cache_place}
+        [[ ${#${(P)cache_place}} -gt 0 ]] && [[ ! -z ${region_highlight-} ]] && region_highlight=(${region_highlight:#(${(P~j.|.)cache_place})})
 
       fi
     done
@@ -82,7 +83,7 @@ _zsh_highlight()
       {
         "_zsh_highlight_${highlighter}_highlighter"
       } always  {
-        : ${(PA)cache_place::=${region_highlight:#(${(~j.|.)region_highlight_copy})}}
+        [[ ! -z ${region_highlight-} ]] && : ${(PA)cache_place::=${region_highlight:#(${(~j.|.)region_highlight_copy})}}
       }
     done
 
@@ -114,7 +115,7 @@ _zsh_highlight_buffer_modified()
 # Returns 0 if the cursor has moved since _zsh_highlight was last called.
 _zsh_highlight_cursor_moved()
 {
-  [[ -n $CURSOR ]] && [[ -n $_ZSH_HIGHLIGHT_PRIOR_CURSOR ]] && (($_ZSH_HIGHLIGHT_PRIOR_CURSOR != $CURSOR))
+  [[ -n $CURSOR ]] && [[ -n ${_ZSH_HIGHLIGHT_PRIOR_CURSOR-} ]] && (($_ZSH_HIGHLIGHT_PRIOR_CURSOR != $CURSOR))
 }
 
 


### PR DESCRIPTION
Hi!

When I had accidentaly appended `setopt no_unset` in my .zshrc,
some errors had occured like "x: parameter not set'. This patch fixes this kind of errors.

Please take a look some time.
