### PR TITLE
Add support for sorin-ionescu's simplified fork of oh-my-zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,22 @@ How to install
         plugins=( [plugins...] zsh-syntax-highlighting)
 
 * Source `~/.zshrc`  to take changes into account:
-    
+
+        source ~/.zshrc
+
+### With sorin-ionescu's simplified oh-my-zsh
+
+* Download the script or clone this repository in [sorin's oh-my-zsh](http://github.com/sorin-ionescu/oh-my-zsh) plugins directory:
+
+        cd ~/.oh-my-zsh/custom/plugins
+        git clone git://github.com/zsh-users/zsh-syntax-highlighting.git
+
+* Activate the plugin in `~/.zshrc` (in **last** position):
+
+        zstyle ':omz:load' plugin [plugins...] 'zsh-syntax-highlighting'
+
+* Source `~/.zshrc`  to take changes into account:
+
         source ~/.zshrc
 
 

--- a/init.zsh
+++ b/init.zsh
@@ -1,0 +1,1 @@
+zsh-syntax-highlighting.zsh


### PR DESCRIPTION
It is the most popular fork of oh-my-zsh (with over 1000 forks of its own!). All it requires is a symlink as init.zsh. I added info to the readme as well, though that may have been overkill.
