### PR TITLE
dollar variable and backslash codes highlighting

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -167,7 +167,7 @@ _zsh_highlight_main_highlighter_check_path()
 _zsh_highlight_main_highlighter_highlight_string()
 {
   setopt localoptions noksharrays
-  local i j k style
+  local i j k style varflag
   # Starting quote is at 1, so start parsing at offset 2 in the string.
   for (( i = 2 ; i < end_pos - start_pos ; i += 1 )) ; do
     (( j = i + start_pos - 1 ))
@@ -175,10 +175,26 @@ _zsh_highlight_main_highlighter_highlight_string()
     case "$arg[$i]" in
       '$')  style=$ZSH_HIGHLIGHT_STYLES[dollar-double-quoted-argument];;
       "\\") style=$ZSH_HIGHLIGHT_STYLES[back-double-quoted-argument]
+            for (( c = i + 1 ; c < end_pos - start_pos ; c += 1 )); do
+              [[ "$arg[$c]" != ([0-9,xX,a-f,A-F]) ]] && break
+            done
+            AA=$arg[$i+1,$c-1]
+            if [[ "$AA" =~ "^(0*(x|X)[0-9,a-f,A-F]{1,2})" || "$AA" =~ "^(0[0-7]{1,3})" ]];then
+              (( k += $#MATCH ))
+              (( i += $#MATCH ))
+            else
+              (( k += 1 )) # Color following char too.
+              (( i += 1 )) # Skip parsing the escaped char.
+            fi
+            (( varflag = 0 ))
             (( k += 1 )) # Color following char too.
             (( i += 1 )) # Skip parsing the escaped char.
             ;;
-      *)    continue;;
+      ([^a-zA-Z0-9_]))
+            (( varflag = 0 ))
+            continue
+            ;;
+      *)    [[ $varflag -eq 0 ]] && continue ;;
     esac
     region_highlight+=("$j $k $style")
   done


### PR DESCRIPTION
Added highlighting of dollar variables and backslash codes (hex and oct) in double quoted strings
![10](https://f.cloud.github.com/assets/2156669/871735/fd07df00-f852-11e2-81f7-c59f45b53cd9.png)
