### PR TITLE
highlight ^old^new pattern

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -128,7 +128,7 @@ _zsh_highlight_main_highlighter()
                           new_expression=true
                         elif _zsh_highlight_main_highlighter_check_path; then
                           style=$ZSH_HIGHLIGHT_STYLES[path]
-                        elif [[ $arg[0,1] = $histchars[0,1] ]]; then
+                        elif [[ $arg[0,1] == $histchars[0,1] || $arg[0,1] == $histchars[2,2] ]]; then
                           style=$ZSH_HIGHLIGHT_STYLES[history-expansion]
                         else
                           style=$ZSH_HIGHLIGHT_STYLES[unknown-token]


### PR DESCRIPTION
Good morning!

I hacked in support for highlighting of the quick substitution syntax, making use of the existing support for highlighting substitutions in doing so.  Let me know if this needs any additional work.  Thanks!
