### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ How to install
 
 ### Using packages
 
-* Arch Linux: [AUR/zsh-syntax-highlighting](https://aur.archlinux.org/packages.php?ID=54171) / [AUR/zsh-syntax-highlighting-git](https://aur.archlinux.org/packages.php?ID=50867)
+* Arch Linux: [community/zsh-syntax-highlighting](https://www.archlinux.org/packages/zsh-syntax-highlighting) / [AUR/zsh-syntax-highlighting-git](https://aur.archlinux.org/packages/zsh-syntax-highlighting-git)
 * Gentoo: [mv overlay](http://gpo.zugaina.org/app-shells/zsh-syntax-highlighting)
 
 ### In your ~/.zshrc


### PR DESCRIPTION
Edited links to Archlinux packages (the link to `zsh-syntax-highlighting-git` is out-of-date, and `zsh-syntax-highlighting` is now available in [community])
