### PR TITLE
Add 'line' highlighter for the whole buffer

### DIFF
--- a/highlighters/README.md
+++ b/highlighters/README.md
@@ -8,6 +8,7 @@ Syntax highlighting is done by pluggable highlighters:
 * [***pattern***](pattern) - matches user-defined patterns.
 * [***cursor***](cursor) - matches the cursor position.
 * [***root***](root) - triggered if the current user is root.
+* [***line***](line) - applied to the whole command line
 
 
 How to activate highlighters

--- a/highlighters/line/README.md
+++ b/highlighters/line/README.md
@@ -1,0 +1,24 @@
+zsh-syntax-highlighting / highlighters / line
+=================================================
+
+This is the ***line*** highlighter, that highlights the whole line.
+
+
+How to activate it
+------------------
+To activate it, add it to `ZSH_HIGHLIGHT_HIGHLIGHTERS`:
+
+    ZSH_HIGHLIGHT_HIGHLIGHTERS=( [...] line)
+
+
+How to tweak it
+---------------
+This highlighter defines the following styles:
+
+* `line` - the style for the whole line
+
+To override one of those styles, change its entry in `ZSH_HIGHLIGHT_STYLES`, for example in `~/.zshrc`:
+
+    ZSH_HIGHLIGHT_STYLES[line]='bold'
+
+The syntax for declaring styles is [documented here](http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#SEC135).

--- a/highlighters/line/line-highlighter.zsh
+++ b/highlighters/line/line-highlighter.zsh
@@ -1,0 +1,45 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2010-2011 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+
+# Define default styles.
+: ${ZSH_HIGHLIGHT_STYLES[line]:=}
+
+# Whether the root highlighter should be called or not.
+_zsh_highlight_line_highlighter_predicate()
+{
+  _zsh_highlight_buffer_modified
+}
+
+# root highlighting function.
+_zsh_highlight_line_highlighter()
+{
+  region_highlight+=("0 $#BUFFER $ZSH_HIGHLIGHT_STYLES[line]")
+}


### PR DESCRIPTION
This is a simple highlighter that applies to the whole buffer. I use it to emphasize the command line by making it bold.

I am not too familiar with Zsh command line highlighting, so if this is already trivial please enlighten me and close the pull request. :-)
