### PR TITLE
README: make installation step 1 more accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ How to install
 
 ### In your ~/.zshrc
 
-* Download the script or clone this repository:
+* [Download](https://github.com/lathan/zsh-syntax-highlighting/archive/master.tar.gz) or clone this repository:
 
         git clone git://github.com/zsh-users/zsh-syntax-highlighting.git
 


### PR DESCRIPTION
You cannot download just the "script". You need the entire directory/repo.

This might seem nitpicky, but a slightly inaccurate instruction can be confusing when in a hurry.
