### PR TITLE
zle: don't override *delete* and *kill*

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -139,7 +139,7 @@ _zsh_highlight_bind_widgets()
 
   # Override ZLE widgets to make them invoke _zsh_highlight.
   local cur_widget
-  for cur_widget in ${${(f)"$(builtin zle -la)"}:#(.*|_*|orig-*|run-help|which-command|beep|yank*)}; do
+  for cur_widget in ${${(f)"$(builtin zle -la)"}:#(.*|_*|orig-*|run-help|which-command|beep|yank*|*delete*|*kill*)}; do
     case $widgets[$cur_widget] in
 
       # Already rebound event: do nothing.


### PR DESCRIPTION
This restores the ability to consecutively delete (ie.) words and
have them come back consecutively in the next yank.
