### PR TITLE
Proposal of text pasting performance issue solution

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -33,6 +33,9 @@
 # Core highlighting update system
 # -------------------------------------------------------------------------------------------------
 
+# Load datetime Zsh module for measuring time delta between keystrokes
+zmodload zsh/datetime
+
 # Array declaring active highlighters names.
 typeset -ga ZSH_HIGHLIGHT_HIGHLIGHTERS
 
@@ -53,6 +56,11 @@ _zsh_highlight()
 
   # Do not highlight if there are pending inputs (copy/paste).
   [[ $PENDING -gt 0 ]] && return $ret
+
+  # Do not highlight if the time delta from previous keystroke is less than 200 ms
+  [[ -z "$LAST_INVOKE_EPOCH" ]] && typeset -g LAST_INVOKE_EPOCH=$EPOCHREALTIME
+  [[ $(( $EPOCHREALTIME - $LAST_INVOKE_EPOCH )) -lt 0.2 ]] && return $ret
+  typeset -g LAST_INVOKE_EPOCH=$EPOCHREALTIME
 
   # Reset region highlight to build it from scratch
   region_highlight=();


### PR DESCRIPTION
As I described in [this comment](https://github.com/zsh-users/zsh-syntax-highlighting/issues/30#issuecomment-66862941), pasting of text to the command line with enabled highlighter is quite pain, and even more on Cygwin. Originally, pasting of 31 characters (what's pretty short) to the command line **took 5 seconds. With my change it's instant.** But it's rather proposal than real solution. I'm not shell programming ninja, so I would welcome any advices to make it better.

**It works like this**: since a condition `[[ $PENDING -gt 0 ]] && return $ret` is not working (at least not on Cygwin), highlighting is executed after each character is inserted while pasting. Therefore I have added another condition after the previous one, which measures delta time between previous and current keystroke. If it's less than 200 ms, highlighting does not continue.

Period of 200 ms was empirically verified like ideal. Shorter periods didn't work.

**There is one thing, which is not ideal in my proposal.** If user presses 2 last keystrokes faster than in 200 ms, highlighting is not executed after the last keystroke. He for example presses few characters and then TAB, which completes the command, in less than 200 ms and ends up with non highlighted command. He has to press for example a space after that to highlight the previous command.

It would be fixed by for example executing of `_zsh_highlight` function periodically, even if no key was pressed (e.g. once per second). Or maybe you'll have some better idea.

In any case, my current solution proposal is way better for me than before. I would rather press a space sometimes to highlight current line than have to wait crazy time to finish a paste. But as I wrote, it's not ideal.

It's interesting that `test-perfs.zsh` measures the same times for both cases, with and without my solution. But pasting is definitely instant.

Also one note to a difference between Cygwin and Linux in relation to performance. Windows doesn't have a `fork`. Creating of a new process is very expensive on Windows. Therefore shell scripts which call a lot of another binaries (or scripts) are much more slower on Cygwin. I have used `date` to get epoch in my first attempt and it was even worse than before. So I have switched to *datetime* Zsh module and using  of `$EPOCHREALTIME` variable instead of `date` command. Condition is evaluated instantly now.

I have created very simple script:
````
COUNTER=50
while [ $COUNTER -gt 0 ]; do
    echo `date +%s`
    let COUNTER=COUNTER-1
done
````

...and there are times it took to execute it under both Cygwin and Linux:

<pre>
system         time
----------------------------
Cygwin         6.091 sec
Linux (VM)     0.062 sec
-----------------------------
</pre>

According to this, it runs 100 times faster on Linux (even in VM) than on Cygwin. But scripts without external calls take similar time on both systems. It's just about creating of a process.