### PR TITLE
README: give the rationale for the at-end-of-.zshrc requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ How to install
         source ~/.zshrc
 
 
+FAQ
+---
+
+### Why must `zsh-syntax-highlighting.zsh` be sourced at the end of the `.zshrc` file?
+
+`zsh-syntax-highlighting.zsh` wraps ZLE widgets.  It must be sourced after all
+custom widgets have been created (`zle -N`).
+
 How to tweak
 ------------
 


### PR DESCRIPTION
The installation instructions in README.md emphasize that zsh-syntax-highlighting
must be sourced at the very end of .zshrc, without explaining why.  This patch
documents the reason for users.