### PR TITLE
Multiline

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -102,7 +102,7 @@ _zsh_highlight_main_highlighter()
     local substr_color=0
     local style_override=""
     [[ $start_pos -eq 0 && $arg = 'noglob' ]] && highlight_glob=false
-    ((start_pos+=${#buf[$start_pos+1,-1]}-${#${buf[$start_pos+1,-1]##[[:space:]]#}}))
+    ((start_pos+=${#buf[$start_pos+1,-1]}-${#${buf[$start_pos+1,-1]##([[:space:]]|\\[[:space:]])#}}))
     ((end_pos=$start_pos+${#arg}))
     # Parse the sudo command line
     if $sudo; then

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -70,8 +70,8 @@ _zsh_highlight_main_add_region_highlight() {
   (( start -= $#PREBUFFER ))
   (( end -= $#PREBUFFER ))
 
-  (( end < 0 )) && return # bug
-  (( start < 0 )) && start=0 # normal with e.g. multiline strings
+  (( end < 0 )) && return # having end<0 would be a bug
+  (( start < 0 )) && start=0 # having start<0 is normal with e.g. multiline strings
   region_highlight+=("$start $end $style")
 }
 
@@ -102,6 +102,7 @@ _zsh_highlight_main_highlighter()
     local substr_color=0
     local style_override=""
     [[ $start_pos -eq 0 && $arg = 'noglob' ]] && highlight_glob=false
+    # advance $start_pos, skipping over whitespace in $buf.
     ((start_pos+=${#buf[$start_pos+1,-1]}-${#${buf[$start_pos+1,-1]##([[:space:]]|\\[[:space:]])#}}))
     ((end_pos=$start_pos+${#arg}))
 

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -177,13 +177,13 @@ _zsh_highlight_main_highlighter()
       case $arg in
         '--'*)   style=$ZSH_HIGHLIGHT_STYLES[double-hyphen-option];;
         '-'*)    style=$ZSH_HIGHLIGHT_STYLES[single-hyphen-option];;
-        "'"*"'") style=$ZSH_HIGHLIGHT_STYLES[single-quoted-argument];;
-        '"'*'"') style=$ZSH_HIGHLIGHT_STYLES[double-quoted-argument]
+        "'"*)    style=$ZSH_HIGHLIGHT_STYLES[single-quoted-argument];;
+        '"'*)    style=$ZSH_HIGHLIGHT_STYLES[double-quoted-argument]
                  _zsh_highlight_main_add_region_highlight $start_pos $end_pos $style
                  _zsh_highlight_main_highlighter_highlight_string
                  substr_color=1
                  ;;
-        '`'*'`') style=$ZSH_HIGHLIGHT_STYLES[back-quoted-argument];;
+        '`'*)    style=$ZSH_HIGHLIGHT_STYLES[back-quoted-argument];;
         *"*"*)   $highlight_glob && style=$ZSH_HIGHLIGHT_STYLES[globbing] || style=$ZSH_HIGHLIGHT_STYLES[default];;
         *)       if _zsh_highlight_main_highlighter_check_path; then
                    style=$ZSH_HIGHLIGHT_STYLES[path]

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -60,6 +60,13 @@ _zsh_highlight_main_highlighter_predicate()
   _zsh_highlight_buffer_modified
 }
 
+# Helper to deal with tokens crossing line boundaries.
+_zsh_highlight_main_add_region_highlight() {
+  integer start=$1 end=$2
+  local style=$3
+  region_highlight+=("$start $end $style")
+}
+
 # Main syntax highlighting function.
 _zsh_highlight_main_highlighter()
 {
@@ -142,7 +149,7 @@ _zsh_highlight_main_highlighter()
         '-'*)    style=$ZSH_HIGHLIGHT_STYLES[single-hyphen-option];;
         "'"*"'") style=$ZSH_HIGHLIGHT_STYLES[single-quoted-argument];;
         '"'*'"') style=$ZSH_HIGHLIGHT_STYLES[double-quoted-argument]
-                 region_highlight+=("$start_pos $end_pos $style")
+                 _zsh_highlight_main_add_region_highlight $start_pos $end_pos $style
                  _zsh_highlight_main_highlighter_highlight_string
                  substr_color=1
                  ;;
@@ -162,7 +169,7 @@ _zsh_highlight_main_highlighter()
     fi
     # if a style_override was set (eg in _zsh_highlight_main_highlighter_check_path), use it
     [[ -n $style_override ]] && style=$ZSH_HIGHLIGHT_STYLES[$style_override]
-    [[ $substr_color = 0 ]] && region_highlight+=("$start_pos $end_pos $style")
+    [[ $substr_color = 0 ]] && _zsh_highlight_main_add_region_highlight $start_pos $end_pos $style
     [[ -n ${(M)ZSH_HIGHLIGHT_TOKENS_FOLLOWED_BY_COMMANDS:#"$arg"} ]] && new_expression=true
     start_pos=$end_pos
   done
@@ -235,6 +242,6 @@ _zsh_highlight_main_highlighter_highlight_string()
       *) [[ $varflag -eq 0 ]] && continue ;;
 
     esac
-    region_highlight+=("$j $k $style")
+    _zsh_highlight_main_add_region_highlight $j $k $style
   done
 }

--- a/highlighters/main/test-data/backslash-continuation.zsh
+++ b/highlighters/main/test-data/backslash-continuation.zsh
@@ -1,0 +1,36 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2015 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+PREBUFFER=$'echo \\\n'
+BUFFER='noglob'
+
+expected_region_highlight=(
+  "0 6 none" # 'noglob' highlighted as a string, not as a precomand
+)

--- a/highlighters/main/test-data/multiline-string.zsh
+++ b/highlighters/main/test-data/multiline-string.zsh
@@ -1,0 +1,37 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2015 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+PREBUFFER=$'echo "foo1\n'
+BUFFER='foo2" ./'
+
+expected_region_highlight=(
+  "0 5 $ZSH_HIGHLIGHT_STYLES[double-quoted-argument]" # 'foo2"'
+  "7 8 $ZSH_HIGHLIGHT_STYLES[path]" # './'
+)

--- a/highlighters/main/test-data/vanilla-newline.zsh
+++ b/highlighters/main/test-data/vanilla-newline.zsh
@@ -29,12 +29,12 @@
 # -------------------------------------------------------------------------------------------------
 
 PREBUFFER=$'echo foo; echo bar\n\n\n'
-BUFFER='echo baz; echo qux'
+BUFFER=' echo baz; echo qux'
 
 expected_region_highlight=(
-  "0 4 $ZSH_HIGHLIGHT_STYLES[builtin]" # echo
-  "5 7 $ZSH_HIGHLIGHT_STYLES[default]" # baz
-  "8 9 $ZSH_HIGHLIGHT_STYLES[default]" # semicolon
-  "11 14 $ZSH_HIGHLIGHT_STYLES[builtin]" # echo
-  "16 18 $ZSH_HIGHLIGHT_STYLES[default]" # qux
+  "1 5 $ZSH_HIGHLIGHT_STYLES[builtin]" # echo
+  "6 8 $ZSH_HIGHLIGHT_STYLES[default]" # baz
+  "9 10 $ZSH_HIGHLIGHT_STYLES[default]" # semicolon
+  "12 15 $ZSH_HIGHLIGHT_STYLES[builtin]" # echo
+  "17 19 $ZSH_HIGHLIGHT_STYLES[default]" # qux
 )

--- a/highlighters/main/test-data/vanilla-newline.zsh
+++ b/highlighters/main/test-data/vanilla-newline.zsh
@@ -1,0 +1,40 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2015 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+PREBUFFER=$'echo foo; echo bar\n\n\n'
+BUFFER='echo baz; echo qux'
+
+expected_region_highlight=(
+  "0 4 $ZSH_HIGHLIGHT_STYLES[builtin]" # echo
+  "5 7 $ZSH_HIGHLIGHT_STYLES[default]" # baz
+  "8 9 $ZSH_HIGHLIGHT_STYLES[default]" # semicolon
+  "11 14 $ZSH_HIGHLIGHT_STYLES[builtin]" # echo
+  "16 18 $ZSH_HIGHLIGHT_STYLES[default]" # qux
+)

--- a/tests/test-highlighting.zsh
+++ b/tests/test-highlighting.zsh
@@ -60,13 +60,13 @@ ZSH_HIGHLIGHT_HIGHLIGHTERS=($1)
 for data_file in ${0:h:h}/highlighters/$1/test-data/*; do
 
   # Load the data and prepare checking it.
-  BUFFER= ; expected_region_highlight=(); errors=()
+  PREBUFFER= BUFFER= ; expected_region_highlight=(); errors=()
   echo -n "* ${data_file:t:r}: "
   . $data_file
 
-  # Check the data declares $BUFFER.
-  if [[ ${#BUFFER} -eq 0 ]]; then
-    errors+=("'BUFFER' is not declared or blank.")
+  # Check the data declares $PREBUFFER or $BUFFER.
+  if [[ ${#PREBUFFER} -eq 0 && ${#BUFFER} -eq 0 ]]; then
+    errors+=("Either 'PREBUFFER' or 'BUFFER' must be declared and non-blank")
   else
 
     # Check the data declares $expected_region_highlight.


### PR DESCRIPTION
The 'main' highlighter does not highlight certain multiline constructs
correctly.  By code inspection, it disregards $PREBUFFER entirely, so any
multiline construct where the start of a line is not a new command would be
misparsed and mishighlighted.  This patch series fixes a few such cases.
Regression tests are included.