### PR TITLE
zle: don't override kill-word and backward-kill-word

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -139,7 +139,7 @@ _zsh_highlight_bind_widgets()
 
   # Override ZLE widgets to make them invoke _zsh_highlight.
   local cur_widget
-  for cur_widget in ${${(f)"$(builtin zle -la)"}:#(.*|_*|orig-*|run-help|which-command|beep|yank*)}; do
+  for cur_widget in ${${(f)"$(builtin zle -la)"}:#(.*|_*|orig-*|run-help|which-command|beep|yank*|backward-kill-word|kill-word)}; do
     case $widgets[$cur_widget] in
 
       # Already rebound event: do nothing.


### PR DESCRIPTION
Otherwise, we can't do `echo hello hello^W^W^Y` and get back `echo hello
hello` (we get `echo hello` instead because ZLE doesn't detect two
consecutive calls to backward-kill-word).

I don't add more to this commit because other `*-kill-*` are less likely
to be used twice in a row when working with the shell. But maybe,
`kill-line` could be added too.

Closes #150.
