### PR TITLE
Fix syntax error with zsh 5.0.7-dev-3

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -228,7 +228,7 @@ _zsh_highlight_main_highlighter_highlight_string()
             fi
               (( varflag = 0 )) # End of variable
             ;;
-      ([^a-zA-Z0-9_]))
+      [^a-zA-Z0-9_])
             (( varflag = 0 )) # End of variable
             continue
             ;;


### PR DESCRIPTION
Commit 35168 (52aeb9aaeb4799b760138a7c34b18ede4b47242a) in zsh changed the parsing of case patterns, resulting in parse errors.  Change the syntax to be compatible with zsh both before and after that commit.