### PR TITLE
Bracketed paste highlight

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -139,7 +139,7 @@ _zsh_highlight_bind_widgets()
 
   # Override ZLE widgets to make them invoke _zsh_highlight.
   local cur_widget
-  for cur_widget in ${${(f)"$(builtin zle -la)"}:#(.*|_*|orig-*|run-help|which-command|beep|yank*)}; do
+  for cur_widget in ${${(f)"$(builtin zle -la)"}:#(.*|_*|orig-*|run-help|bracketed-paste|which-command|beep|yank*)}; do
     case $widgets[$cur_widget] in
 
       # Already rebound event: do nothing.

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -139,7 +139,7 @@ _zsh_highlight_bind_widgets()
 
   # Override ZLE widgets to make them invoke _zsh_highlight.
   local cur_widget
-  for cur_widget in ${${(f)"$(builtin zle -la)"}:#(.*|_*|orig-*|run-help|bracketed-paste|which-command|beep|yank*)}; do
+  for cur_widget in ${${(f)"$(builtin zle -la)"}:#(.*|_*|orig-*|run-help|bracketed-paste|vi-put-before|vi-put-after|which-command|beep|yank*)}; do
     case $widgets[$cur_widget] in
 
       # Already rebound event: do nothing.


### PR DESCRIPTION
zsh has grown a feature whereby pasted text can be highlighted. These patches are required for the new upstream feature to work when zsh-syntax-highlighting has been loaded.