### PR TITLE
Don't parse first word of array assignment as command

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -125,7 +125,11 @@ _zsh_highlight_main_highlighter()
         *': hashed')    style=$ZSH_HIGHLIGHT_STYLES[hashed-command];;
         *)              if _zsh_highlight_main_highlighter_check_assign; then
                           style=$ZSH_HIGHLIGHT_STYLES[assign]
-                          new_expression=true
+                          if [[ $arg[-1] != '(' ]]; then
+                            # assignment to a scalar parameter.
+                            # (For array assignments, the command doesn't start until the ")" token.)
+                            new_expression=true
+                          fi
                         elif _zsh_highlight_main_highlighter_check_path; then
                           style=$ZSH_HIGHLIGHT_STYLES[path]
                         elif [[ $arg[0,1] == $histchars[0,1] || $arg[0,1] == $histchars[2,2] ]]; then

--- a/highlighters/main/test-data/assign.zsh
+++ b/highlighters/main/test-data/assign.zsh
@@ -28,8 +28,9 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
-BUFFER='A=1'
+BUFFER='A=1 b=("foo" bar)'
 
 expected_region_highlight=(
   "1 3 $ZSH_HIGHLIGHT_STYLES[assign]" # A=1
+  "8 12 $ZSH_HIGHLIGHT_STYLES[double-quoted-argument]" # "foo"
 )


### PR DESCRIPTION
Fixes issue #178.  Similar to the patch in the second comment on that issue, but adds a regression test as well.