### PR TITLE
README.md: install with oh-my-zsh in a single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ How to install
 
 * Download the script or clone this repository in [oh-my-zsh](http://github.com/robbyrussell/oh-my-zsh) plugins directory:
 
-        cd ~/.oh-my-zsh/custom/plugins
-        git clone git://github.com/zsh-users/zsh-syntax-highlighting.git
+        git clone git://github.com/zsh-users/zsh-syntax-highlighting.git ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
 
 * Activate the plugin in `~/.zshrc`:
 


### PR DESCRIPTION
No need to `cd` to the directory (especially if you’re installing this plugin as part of a bigger script).