### PR TITLE
Add support for themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This branch will be rebased from time to time.**
+
 zsh-syntax-highlighting
 =======================
 

--- a/docs/highlighters.md
+++ b/docs/highlighters.md
@@ -42,6 +42,18 @@ page][zshzle-Character-Highlighting].
 
 [zshzle-Character-Highlighting]: http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting
 
+Styles may be set directly or by themes. If no theme is specified in
+`ZSH_HIGHLIGHT_THEME` the `default` theme will be loaded. Additional themes
+may be layered on top (overriding previous theme's settings) by calling
+`_zsh_highlight_load_theme`.  `_zsh_highlight_load_theme` takes either an
+absolute path to a theme file to load or a theme name. For a theme name the
+base theme from the themes directory is loaded and then the extensions of the
+theme that any active highlighter has are loaded. Names must not contain a `/`.
+
+The `default` theme is a colorful theme that preserves the defaults the
+highlighters originally had. The `error-only` theme is also available for
+highlighting only syntax errors.
+
 Some highlighters support additional configuration parameters; see each
 highlighter's documentation for details and examples.
 
@@ -66,12 +78,8 @@ To create your own `acme` highlighter:
 * Implement the `_zsh_highlight_highlighter_acme_paint` function.
   This function does the actual syntax highlighting, by calling
   `_zsh_highlight_add_highlight` with the start and end of the region to
-  be highlighted and the `ZSH_HIGHLIGHT_STYLES` key to use. Define the default
-  style for that key in the highlighter script outside of any function with
-  `: ${ZSH_HIGHLIGHT_STYLES[key]:=value}`, being sure to prefix
-  the key with your highlighter name and a colon. For example:
-
-        : ${ZSH_HIGHLIGHT_STYLES[acme:aurora]:=fg=green}
+  be highlighted and the `ZSH_HIGHLIGHT_STYLES` key to use. The key should
+  be prefixed with your highlighter name and a colon
 
         _zsh_highlight_highlighter_acme_paint() {
           # Colorize the whole buffer with the 'aurora' style
@@ -89,6 +97,15 @@ To create your own `acme` highlighter:
 
         These names are still supported for backwards compatibility;
         however, support for them will be removed in a a future major or minor release (v0.x.0 or v1.0.0).
+
+* Optionally extended the built-in themes in
+    `highlighters/${myhighlighter}/themes/${themename}`.
+
+  Define the theme's style for that key with `ZSH_HIGHLIGHT_STYLES[key]=value`,
+  being sure to prefix the key with your highlighter name and a colon. For
+  example:
+
+        ZSH_HIGHLIGHT_STYLES[myhighlighter:aurora]=fg=green
 
 * Activate your highlighter in `~/.zshrc`:
 

--- a/highlighters/brackets/brackets-highlighter.zsh
+++ b/highlighters/brackets/brackets-highlighter.zsh
@@ -28,15 +28,6 @@
 # -------------------------------------------------------------------------------------------------
 
 
-# Define default styles.
-: ${ZSH_HIGHLIGHT_STYLES[bracket-error]:=fg=red,bold}
-: ${ZSH_HIGHLIGHT_STYLES[bracket-level-1]:=fg=blue,bold}
-: ${ZSH_HIGHLIGHT_STYLES[bracket-level-2]:=fg=green,bold}
-: ${ZSH_HIGHLIGHT_STYLES[bracket-level-3]:=fg=magenta,bold}
-: ${ZSH_HIGHLIGHT_STYLES[bracket-level-4]:=fg=yellow,bold}
-: ${ZSH_HIGHLIGHT_STYLES[bracket-level-5]:=fg=cyan,bold}
-: ${ZSH_HIGHLIGHT_STYLES[cursor-matchingbracket]:=standout}
-
 # Whether the brackets highlighter should be called or not.
 _zsh_highlight_highlighter_brackets_predicate()
 {

--- a/highlighters/cursor/cursor-highlighter.zsh
+++ b/highlighters/cursor/cursor-highlighter.zsh
@@ -28,9 +28,6 @@
 # -------------------------------------------------------------------------------------------------
 
 
-# Define default styles.
-: ${ZSH_HIGHLIGHT_STYLES[cursor]:=standout}
-
 # Whether the cursor highlighter should be called or not.
 _zsh_highlight_highlighter_cursor_predicate()
 {

--- a/highlighters/line/line-highlighter.zsh
+++ b/highlighters/line/line-highlighter.zsh
@@ -28,9 +28,6 @@
 # -------------------------------------------------------------------------------------------------
 
 
-# Define default styles.
-: ${ZSH_HIGHLIGHT_STYLES[line]:=}
-
 # Whether the root highlighter should be called or not.
 _zsh_highlight_highlighter_line_predicate()
 {

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -28,32 +28,6 @@
 # -------------------------------------------------------------------------------------------------
 
 
-# Define default styles.
-: ${ZSH_HIGHLIGHT_STYLES[default]:=none}
-: ${ZSH_HIGHLIGHT_STYLES[unknown-token]:=fg=red,bold}
-: ${ZSH_HIGHLIGHT_STYLES[reserved-word]:=fg=yellow}
-: ${ZSH_HIGHLIGHT_STYLES[suffix-alias]:=fg=green,underline}
-: ${ZSH_HIGHLIGHT_STYLES[precommand]:=fg=green,underline}
-: ${ZSH_HIGHLIGHT_STYLES[commandseparator]:=none}
-: ${ZSH_HIGHLIGHT_STYLES[path]:=underline}
-: ${ZSH_HIGHLIGHT_STYLES[path_pathseparator]:=}
-: ${ZSH_HIGHLIGHT_STYLES[path_prefix_pathseparator]:=}
-: ${ZSH_HIGHLIGHT_STYLES[globbing]:=fg=blue}
-: ${ZSH_HIGHLIGHT_STYLES[history-expansion]:=fg=blue}
-: ${ZSH_HIGHLIGHT_STYLES[single-hyphen-option]:=none}
-: ${ZSH_HIGHLIGHT_STYLES[double-hyphen-option]:=none}
-: ${ZSH_HIGHLIGHT_STYLES[back-quoted-argument]:=none}
-: ${ZSH_HIGHLIGHT_STYLES[single-quoted-argument]:=fg=yellow}
-: ${ZSH_HIGHLIGHT_STYLES[double-quoted-argument]:=fg=yellow}
-: ${ZSH_HIGHLIGHT_STYLES[dollar-quoted-argument]:=fg=yellow}
-: ${ZSH_HIGHLIGHT_STYLES[dollar-double-quoted-argument]:=fg=cyan}
-: ${ZSH_HIGHLIGHT_STYLES[back-double-quoted-argument]:=fg=cyan}
-: ${ZSH_HIGHLIGHT_STYLES[back-dollar-quoted-argument]:=fg=cyan}
-: ${ZSH_HIGHLIGHT_STYLES[assign]:=none}
-: ${ZSH_HIGHLIGHT_STYLES[redirection]:=none}
-: ${ZSH_HIGHLIGHT_STYLES[comment]:=fg=black,bold}
-: ${ZSH_HIGHLIGHT_STYLES[arg0]:=fg=green}
-
 # Whether the highlighter should be called or not.
 _zsh_highlight_highlighter_main_predicate()
 {

--- a/highlighters/root/root-highlighter.zsh
+++ b/highlighters/root/root-highlighter.zsh
@@ -28,9 +28,6 @@
 # -------------------------------------------------------------------------------------------------
 
 
-# Define default styles.
-: ${ZSH_HIGHLIGHT_STYLES[root]:=standout}
-
 # Whether the root highlighter should be called or not.
 _zsh_highlight_highlighter_root_predicate()
 {

--- a/themes/default
+++ b/themes/default
@@ -1,0 +1,43 @@
+# brackets
+ZSH_HIGHLIGHT_STYLES[bracket-error]=fg=red,bold
+ZSH_HIGHLIGHT_STYLES[bracket-level-1]=fg=blue,bold
+ZSH_HIGHLIGHT_STYLES[bracket-level-2]=fg=green,bold
+ZSH_HIGHLIGHT_STYLES[bracket-level-3]=fg=magenta,bold
+ZSH_HIGHLIGHT_STYLES[bracket-level-4]=fg=yellow,bold
+ZSH_HIGHLIGHT_STYLES[bracket-level-5]=fg=cyan,bold
+ZSH_HIGHLIGHT_STYLES[cursor-matchingbracket]=standout
+
+# cursor
+ZSH_HIGHLIGHT_STYLES[cursor]=standout
+
+# line
+ZSH_HIGHLIGHT_STYLES[line]=
+
+# main
+ZSH_HIGHLIGHT_STYLES[default]=none
+ZSH_HIGHLIGHT_STYLES[unknown-token]=fg=red,bold
+ZSH_HIGHLIGHT_STYLES[reserved-word]=fg=yellow
+ZSH_HIGHLIGHT_STYLES[suffix-alias]=fg=green,underline
+ZSH_HIGHLIGHT_STYLES[precommand]=fg=green,underline
+ZSH_HIGHLIGHT_STYLES[commandseparator]=none
+ZSH_HIGHLIGHT_STYLES[path]=underline
+ZSH_HIGHLIGHT_STYLES[path_pathseparator]=
+ZSH_HIGHLIGHT_STYLES[path_prefix_pathseparator]=
+ZSH_HIGHLIGHT_STYLES[globbing]=fg=blue
+ZSH_HIGHLIGHT_STYLES[history-expansion]=fg=blue
+ZSH_HIGHLIGHT_STYLES[single-hyphen-option]=none
+ZSH_HIGHLIGHT_STYLES[double-hyphen-option]=none
+ZSH_HIGHLIGHT_STYLES[back-quoted-argument]=none
+ZSH_HIGHLIGHT_STYLES[single-quoted-argument]=fg=yellow
+ZSH_HIGHLIGHT_STYLES[double-quoted-argument]=fg=yellow
+ZSH_HIGHLIGHT_STYLES[dollar-quoted-argument]=fg=yellow
+ZSH_HIGHLIGHT_STYLES[dollar-double-quoted-argument]=fg=cyan
+ZSH_HIGHLIGHT_STYLES[back-double-quoted-argument]=fg=cyan
+ZSH_HIGHLIGHT_STYLES[back-dollar-quoted-argument]=fg=cyan
+ZSH_HIGHLIGHT_STYLES[assign]=none
+ZSH_HIGHLIGHT_STYLES[redirection]=none
+ZSH_HIGHLIGHT_STYLES[comment]=fg=black,bold
+ZSH_HIGHLIGHT_STYLES[arg0]=fg=green
+
+# root
+ZSH_HIGHLIGHT_STYLES[root]=standout

--- a/themes/error-only
+++ b/themes/error-only
@@ -1,0 +1,2 @@
+ZSH_HIGHLIGHT_STYLES[bracket-error]=fg=red,bold
+ZSH_HIGHLIGHT_STYLES[unknown-token]=fg=red,bold

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -376,6 +376,24 @@ _zsh_highlight_load_highlighters()
 }
 
 
+# Load theme
+# $1 should be a theme defined in themes/ or an absolute path
+_zsh_highlight_load_theme()
+{
+  local theme=$1
+  shift 1
+  if [[ ${theme[1]} == / ]]; then
+    source $theme
+  elif [[ $theme == */* ]]; then
+    print -r -- >&2 "zsh-syntax-highlighting: failed on invalid theme name: ${(qq)theme}"
+    return 1
+  else
+    for theme in ${ZSH_HIGHLIGHT_HIGHLIGHTERS_DIR:h}/themes/$theme(N) $ZSH_HIGHLIGHT_HIGHLIGHTERS_DIR/$^ZSH_HIGHLIGHT_HIGHLIGHTERS/$theme(N); do
+      source $theme
+    done
+  fi
+}
+
 # -------------------------------------------------------------------------------------------------
 # Setup
 # -------------------------------------------------------------------------------------------------
@@ -387,7 +405,7 @@ _zsh_highlight_bind_widgets || {
 }
 
 # Resolve highlighters directory location.
-_zsh_highlight_load_highlighters "${ZSH_HIGHLIGHT_HIGHLIGHTERS_DIR:-${${0:A}:h}/highlighters}" || {
+_zsh_highlight_load_highlighters "${ZSH_HIGHLIGHT_HIGHLIGHTERS_DIR:=${${0:A}:h}/highlighters}" || {
   print -r -- >&2 'zsh-syntax-highlighting: failed loading highlighters, exiting.'
   return 1
 }
@@ -408,6 +426,9 @@ zmodload zsh/parameter 2>/dev/null || true
 
 # Initialize the array of active highlighters if needed.
 [[ $#ZSH_HIGHLIGHT_HIGHLIGHTERS -eq 0 ]] && ZSH_HIGHLIGHT_HIGHLIGHTERS=(main)
+
+# Load the theme.
+_zsh_highlight_load_theme "${ZSH_HIGHLIGHT_THEME-default}"
 
 # Restore the aliases we unned
 eval "$zsh_highlight__aliases"


### PR DESCRIPTION
I'm not yet happy with loading a local theme. If a user sets ZSH_HIGHLIGHT_THEME=error-only and then happens to have a file in their current directory called error-only, it will pick that up.
