### PR TITLE
docs: Further tweaks after recent refactoring branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ How to tweak
 ------------
 
 Syntax highlighting is done by pluggable highlighter scripts.  See the
-[`highlighters` directory](./highlighters) for documentation and configuration
-settings.
+[documentation on highlighters](docs/highlighters.md) for details and
+configuration settings.

--- a/docs/highlighters.md
+++ b/docs/highlighters.md
@@ -35,7 +35,7 @@ manual page][zshzle-Character-Highlighting].
 [zshzle-Character-Highlighting]: http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting
 
 Some highlighters support additional configuration parameters; see each
-highlighter's documentation for details.
+highlighter's documentation for details and examples.
 
 
 How to implement a new highlighter

--- a/docs/highlighters.md
+++ b/docs/highlighters.md
@@ -27,10 +27,11 @@ How to tweak highlighters
 -------------------------
 
 Highlighters look up styles from the `ZSH_HIGHLIGHT_STYLES` associative array.
-Navigate into each highlighter directory to see what styles (keys) it defines;
-the syntax for values is the same as the syntax of "types of highlighting" of
-the zsh builtin `$zle_highlight` array, which is documented in [the `zshzle(1)`
-manual page][zshzle-Character-Highlighting].
+Navigate into the [individual highlighters' documentation](highlighters/) to
+see what styles (keys) each highlighter defines; the syntax for values is the
+same as the syntax of "types of highlighting" of the zsh builtin
+`$zle_highlight` array, which is documented in [the `zshzle(1)` manual
+page][zshzle-Character-Highlighting].
 
 [zshzle-Character-Highlighting]: http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting
 

--- a/docs/highlighters.md
+++ b/docs/highlighters.md
@@ -3,12 +3,12 @@ zsh-syntax-highlighting / highlighters
 
 Syntax highlighting is done by pluggable highlighters:
 
-* `main` - the base highlighter, and the only one active by default.
-* `brackets` - matches brackets and parenthesis.
-* `pattern` - matches user-defined patterns.
-* `cursor` - matches the cursor position.
-* `root` - triggered if the current user is root.
-* `line` - applied to the whole command line
+* `main` - the base highlighter, and the only one [active by default](highlighters/main.md).
+* `brackets` - [matches brackets](highlighters/brackets.md) and parenthesis.
+* `pattern` - matches [user-defined patterns](highlighters/pattern.md).
+* `cursor` - matches [the cursor](highlighters/cursor.md) position.
+* `root` - triggered [if the current user is root](highlighters/root.md).
+* `line` - applied to [the whole command line](highlighters/line.md).
 
 
 How to activate highlighters

--- a/docs/highlighters.md
+++ b/docs/highlighters.md
@@ -7,7 +7,7 @@ Syntax highlighting is done by pluggable highlighters:
 * `brackets` - [matches brackets](highlighters/brackets.md) and parenthesis.
 * `pattern` - matches [user-defined patterns](highlighters/pattern.md).
 * `cursor` - matches [the cursor](highlighters/cursor.md) position.
-* `root` - triggered [if the current user is root](highlighters/root.md).
+* `root` - highlights the whole command line [if the current user is root](highlighters/root.md).
 * `line` - applied to [the whole command line](highlighters/line.md).
 
 

--- a/highlighters/README.md
+++ b/highlighters/README.md
@@ -1,1 +1,8 @@
-../docs/highlighters.md
+zsh-syntax-highlighting / highlighters
+======================================
+
+Navigate into the individual highlighters' documentation to see
+what styles (`$ZSH_HIGHLIGHT_STYLES` keys) each highlighter defines.
+
+Refer to the [documentation on highlighters](../docs/highlighters.md) for further
+information.


### PR DESCRIPTION
A few further cleanups to `highlighters/README.md`, disentangling the landing page from `docs/highlighters.md` which is now the canonical point.

Open questions:
- There are no references whatsoever to `all.md`
- 02b7e2f55ef9 reduces the readability of `docs/highlighters.md` in source form (in `less`)