### PR TITLE
[#148] command being typed as neither green nor red

### DIFF
--- a/docs/highlighters/main.md
+++ b/docs/highlighters/main.md
@@ -26,6 +26,7 @@ This highlighter defines the following styles:
 * `precommand` - precommand modifiers (e.g., `noglob`, `builtin`)
 * `commandseparator` - command separation tokens (`;`, `&&`)
 * `hashed-command` - hashed commands
+* `command-being-typed` - prefix of a command/function/alias that isn't one itself (e.g., `sourc`, `ifconfi`)
 * `path` - existing filenames
 * `path_prefix` - prefixes of existing filenames
 * `globbing` - globbing expressions (`*.txt`)

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -40,6 +40,7 @@
 : ${ZSH_HIGHLIGHT_STYLES[precommand]:=fg=green,underline}
 : ${ZSH_HIGHLIGHT_STYLES[commandseparator]:=none}
 : ${ZSH_HIGHLIGHT_STYLES[hashed-command]:=fg=green}
+: ${ZSH_HIGHLIGHT_STYLES[command-being-typed]:=fg=yellow,underline}
 : ${ZSH_HIGHLIGHT_STYLES[path]:=underline}
 : ${ZSH_HIGHLIGHT_STYLES[path_prefix]:=underline}
 : ${ZSH_HIGHLIGHT_STYLES[globbing]:=fg=blue}
@@ -347,6 +348,8 @@ _zsh_highlight_main_highlighter()
                         else
                           if _zsh_highlight_main_highlighter_check_path; then
                             style=$ZSH_HIGHLIGHT_STYLES[path]
+                          elif (( ${#BUFFER} == $end_pos )); then
+                            style=$ZSH_HIGHLIGHT_STYLES[command-being-typed]
                           else
                             style=$ZSH_HIGHLIGHT_STYLES[unknown-token]
                           fi

--- a/highlighters/main/test-data/unknown-command.zsh
+++ b/highlighters/main/test-data/unknown-command.zsh
@@ -27,8 +27,10 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
-BUFFER='azertyuiop'
+# Do not append to the BUFFER; the second instance tests an "at end of BUFFER" feature.
+BUFFER='azertyuiop; azertyuiop'
 
 expected_region_highlight=(
   "1  10  $ZSH_HIGHLIGHT_STYLES[unknown-token]" # azertyuiop
+  "13 22  $ZSH_HIGHLIGHT_STYLES[command-being-typed]" # azertyuiop, at end of buffer
 )


### PR DESCRIPTION
Related to #148: this patch adds a highlight style for the command word, while it is being typed (similar to `path_prefix`).

The style used is yellow underline, the same style the now-removed `path_approx` used.

The intention is to avoid the unknown-token style whilst inputting the command. Future changes may fine tune this further (as discussed in #148), for example, only use the new style when the input-so-far is a prefix of a command or function name.
