### PR TITLE
properly rebind more relevant zle widgets

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -200,7 +200,7 @@ _zsh_highlight_bind_widgets()
 
   # Override ZLE widgets to make them invoke _zsh_highlight.
   local cur_widget
-  for cur_widget in ${${(f)"$(builtin zle -la)"}:#(.*|_*|orig-*|run-help|which-command|beep|set-local-history|yank)}; do
+  for cur_widget in ${${(f)"$(builtin zle -la)"}:#(.*|orig-*|run-help|which-command|beep|set-local-history|yank)}; do
     case $widgets[$cur_widget] in
 
       # Already rebound event: do nothing.

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -204,7 +204,7 @@ _zsh_highlight_bind_widgets()
     case $widgets[$cur_widget] in
 
       # Already rebound event: do nothing.
-      user:$cur_widget|user:_zsh_highlight_widget_*);;
+      user:_zsh_highlight_widget_*);;
 
       # User defined widget: override and rebind old one with prefix "orig-".
       user:*) eval "zle -N orig-$cur_widget ${widgets[$cur_widget]#*:}; \


### PR DESCRIPTION
- Just because a widget starts with _ does not mean it should be
  skipped when rebinding. The only reason widgets need to be skipped
  is when their function name start with _zsh_highlight_widget_*,
  which is checked later.

  Example:
  _expand_alias (^Xa) needs to be wrapped.

- Skipping when $cur_widgets == user:$cur_widget is wrong.
  This skips widgets whose function name is identical to
  the widget name and is not related to _zsh_highlight_widget_.

  Example:
  expand-absolute-path is a widget whose function name is also
  expand-absolute-path. No reason why this should be ignored.