### PR TITLE
Do not highlight in isearch widgets

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -66,6 +66,12 @@ _zsh_highlight()
   setopt localoptions noksharrays
   local REPLY # don't leak $REPLY into global scope
 
+  # Do not highlight in isearch widgets.
+  if [[ $WIDGET == zle-isearch-update ]]; then
+    region_highlight=()
+    return $ret
+  fi
+
   # Do not highlight if there are more than 300 chars in the buffer. It's most
   # likely a pasted command or a huge list of files in that case..
   [[ -n ${ZSH_HIGHLIGHT_MAXLENGTH:-} ]] && [[ $#BUFFER -gt $ZSH_HIGHLIGHT_MAXLENGTH ]] && return $ret


### PR DESCRIPTION
As long as zle_highlight for the isearch region can't be applied
properly *after* zsh-syntax-highlighting is done it does not make
sense to apply any highlighting while isearch is active.

Otherwise its almost impossible to see the matched area.