### PR TITLE
treat zle-isearch-exit like an accept-* widget

### DIFF
--- a/highlighters/cursor/cursor-highlighter.zsh
+++ b/highlighters/cursor/cursor-highlighter.zsh
@@ -34,15 +34,14 @@
 # Whether the cursor highlighter should be called or not.
 _zsh_highlight_cursor_highlighter_predicate()
 {
-  # accept-* may trigger removal of cursor highlighting
-  [[ $WIDGET == accept-* ]] ||
-    _zsh_highlight_cursor_moved
+  # widgets which accept lines may trigger removal of cursor highlighting
+  _zsh_highlight_cursor_moved || _zsh_highlight_is_accept_line_type_widget
 }
 
 # Cursor highlighting function.
 _zsh_highlight_cursor_highlighter()
 {
-  [[ $WIDGET == accept-* ]] && return
-  
+  _zsh_highlight_is_accept_line_type_widget && return
+
   region_highlight+=("$CURSOR $(( $CURSOR + 1 )) $ZSH_HIGHLIGHT_STYLES[cursor]")
 }

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -60,8 +60,8 @@
 # Whether the highlighter should be called or not.
 _zsh_highlight_main_highlighter_predicate()
 {
-  # accept-* may trigger removal of path_prefix highlighting
-  [[ $WIDGET == accept-* ]] ||
+  # widgets which accept lines may trigger removal of path_prefix highlighting
+  _zsh_highlight_is_accept_line_type_widget ||
     _zsh_highlight_buffer_modified
 }
 
@@ -455,7 +455,7 @@ _zsh_highlight_main_highlighter_check_path()
 
   # If this word ends the buffer, check if it's the prefix of a valid path.
   if [[ ${BUFFER[1]} != "-" && ${#BUFFER} == $end_pos ]] &&
-     [[ $WIDGET != accept-* ]]; then
+     ! _zsh_highlight_is_accept_line_type_widget; then
     local -a tmp
     tmp=( ${expanded_path}*(N) )
     (( $#tmp > 0 )) && style_override=path_prefix && return 0

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -174,6 +174,14 @@ _zsh_highlight_cursor_moved()
   [[ -n $CURSOR ]] && [[ -n ${_ZSH_HIGHLIGHT_PRIOR_CURSOR-} ]] && (($_ZSH_HIGHLIGHT_PRIOR_CURSOR != $CURSOR))
 }
 
+# Whether the current widget is an accept-line type widget.
+#
+# Returns 0 if the the current widget is an accept-line type widget.
+_zsh_highlight_is_accept_line_type_widget()
+{
+  [[ $WIDGET == accept-* ]] || [[ $WIDGET == zsh-isearch-exit ]]
+}
+
 
 # -------------------------------------------------------------------------------------------------
 # Setup functions


### PR DESCRIPTION
When hitting ENTER in an isearch, the cursor imprint needs to be removed, and any path_prefix highlighting needs to be removed.

See 4f0c293fdef047cda6bb7574187f952c38643fc9 and 59fbdda64c21dd9e911329f31fbbedc69123865b.

Does it make sense to keep this a a user-configurable setting? The pattern matching is a bit complex.
It is ony useful if the user has custom widgets that call accpt-* internally. But then one could argue, that the custom widget name should start with accept-, too.