### PR TITLE
highlight path separators

### DIFF
--- a/docs/highlighters/main.md
+++ b/docs/highlighters/main.md
@@ -27,7 +27,9 @@ This highlighter defines the following styles:
 * `commandseparator` - command separation tokens (`;`, `&&`)
 * `hashed-command` - hashed commands
 * `path` - existing filenames
+* `path_pathseparator` - path separators in filenames (`/`), if unset, `path` is used (default)
 * `path_prefix` - prefixes of existing filenames
+* `path_prefix_pathseparator` - path separators in prefixes of existing filenames (`/`), if unset, `path_prefix` is used (default)
 * `globbing` - globbing expressions (`*.txt`)
 * `history-expansion` - history expansion expressions (`!foo` and `^foo^bar`)
 * `single-hyphen-option` - single hyphen options (`-o`)

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -41,9 +41,9 @@
 : ${ZSH_HIGHLIGHT_STYLES[commandseparator]:=none}
 : ${ZSH_HIGHLIGHT_STYLES[hashed-command]:=fg=green}
 : ${ZSH_HIGHLIGHT_STYLES[path]:=underline}
-: ${ZSH_HIGHLIGHT_STYLES[path_pathseparator]:=${ZSH_HIGHLIGHT_STYLES[path]}}
+: ${ZSH_HIGHLIGHT_STYLES[path_pathseparator]:=}
 : ${ZSH_HIGHLIGHT_STYLES[path_prefix]:=underline}
-: ${ZSH_HIGHLIGHT_STYLES[path_prefix_pathseparator]:=${ZSH_HIGHLIGHT_STYLES[path_prefix]}}
+: ${ZSH_HIGHLIGHT_STYLES[path_prefix_pathseparator]:=}
 : ${ZSH_HIGHLIGHT_STYLES[globbing]:=fg=blue}
 : ${ZSH_HIGHLIGHT_STYLES[history-expansion]:=fg=blue}
 : ${ZSH_HIGHLIGHT_STYLES[single-hyphen-option]:=none}


### PR DESCRIPTION
This commit is a squash of the work done by
Jorge Israel Peña (blaenk) in #136,
rebased on the latest master branch.

For now, this is disabled in tests, because they all would need to be adjusted.

TODO: If the ZSH_HIGHLIGHT_DISABLE_PATHSEP option should stay, it needs to be documented.