### PR TITLE
use zle-line-pre-redraw hook if available

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -262,14 +262,22 @@ _zsh_highlight_bind_widgets()
   local -U widgets_to_bind
   widgets_to_bind=(${${(k)widgets}:#(.*|run-help|which-command|beep|set-local-history|yank)})
 
-  # Always wrap special zle-line-finish widget. This is needed to decide if the
-  # current line ends and special highlighting logic needs to be applied.
-  # E.g. remove cursor imprint, don't highlight partial paths, ...
-  widgets_to_bind+=(zle-line-finish)
+  # Use zle-line-pre-redraw if available. Otherwise try binding widgets as fallback.
+  autoload -Uz is-at-least
+  if is-at-least 5.2; then
+    widgets_to_bind=(zle-line-pre-redraw)
+  else
+    widgets_to_bind=(${${(f)"$(builtin zle -la)"}:#(.*|orig-*|run-help|which-command|beep|set-local-history|yank)})
 
-  # Always wrap special zle-isearch-update widget to be notified of updates in isearch.
-  # This is needed because we need to disable highlighting in that case.
-  widgets_to_bind+=(zle-isearch-update)
+    # Always wrap special zle-line-finish widget. This is needed to decide if the
+    # current line ends and special highlighting logic needs to be applied.
+    # E.g. remove cursor imprint, don't highlight partial paths, ...
+    widgets_to_bind+=(zle-line-finish)
+
+    # Always wrap special zle-isearch-update widget to be notified of updates in isearch.
+    # This is needed because we need to disable highlighting in that case.
+    widgets_to_bind+=(zle-isearch-update)
+  fi
 
   local cur_widget
   for cur_widget in $widgets_to_bind; do


### PR DESCRIPTION
The widget binding logic is kept, so that old versions of zsh still work as before.

_zsh_highlight_bind_widgets now accepts parameters, to specify which widgets to bind.

This is needed because with the redraw-hook we are not notifed for zle-isearch-* anymore, but we still need to react on those. Maybe this is an upstream issue?

TODO: The version numer in is-at-least actually needs to be 5.2.1, once officially released.

This fixes #245.