### PR TITLE
region: Highlight the region even when it's inactive, e.g., after <set-mark-command>

### DIFF
--- a/highlighters/main/test-data/mark.zsh
+++ b/highlighters/main/test-data/mark.zsh
@@ -1,0 +1,37 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2016 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+zle_highlight=(region:$unused_highlight)
+BUFFER='echo hello world'
+MARK=5
+CURSOR=$#BUFFER
+
+expected_region_highlight=(
+  "6 16 ${(q)unused_highlight}" # hello world; zle_high
+)

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -114,7 +114,7 @@ _zsh_highlight()
 
     # Re-apply zle_highlight settings
     () {
-      if (( REGION_ACTIVE )) ; then
+      if (( MARK > 0 )) || (( REGION_ACTIVE )) ; then
         # zle_highlight[region] defaults to 'standout' if unspecified
         local region="${${zle_highlight[(r)region:*]#region:}:-standout}"
         integer start end


### PR DESCRIPTION
Sometimes I type `echo hello <set-mark-command>world<quote-region>` (the default bindings are &lt;C-Space&gt; and &lt;M-"&gt; respectively).  This patch will cause the word `world` to be highlighted whilst its being typed.

Should an inactive region be highlighted differently from an active one?  Some widgets behave differently on active and inactive regions, e.g., pasting will delete the region only the region is active.  There are more differences, particularly in vi mode (grep Src/Zle/ for if/switch statements on the C variable `region_active`).

/cc @m0vie - this is in the same general area as #256 and #257
