### PR TITLE
Adjust plugin.zsh file to run on zsh 5.1 in mSYS2.

### DIFF
--- a/zsh-syntax-highlighting.plugin.zsh
+++ b/zsh-syntax-highlighting.plugin.zsh
@@ -1,1 +1,1 @@
-source $(dirname $0)/zsh-syntax-highlighting.zsh
+source $0:A:h/zsh-syntax-highlighting.zsh

--- a/zsh-syntax-highlighting.plugin.zsh
+++ b/zsh-syntax-highlighting.plugin.zsh
@@ -1,1 +1,1 @@
-zsh-syntax-highlighting.zsh
+source $(dirname $0)/zsh-syntax-highlighting.zsh


### PR DESCRIPTION
A sole filename caused "command not found" errors while loading with zplug or oh-no-zsh on zsh 5.1.1 inside mSYS2 (Windows).
Sourcing the main file seems to work fine.