### PR TITLE
Avoid forks to improve performance (especially on Cygwin)

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -89,6 +89,10 @@ _zsh_highlight_main_add_region_highlight() {
 #
 # The result will be stored in REPLY.
 _zsh_highlight_main__type() {
+  REPLY=$_zsh_highlight_command_type_cache[(e)$1]
+  if [[ -n "$REPLY" ]]; then
+    return
+  fi
   if (( $#options_to_set )); then
     setopt localoptions $options_to_set;
   fi
@@ -113,6 +117,7 @@ _zsh_highlight_main__type() {
   if ! (( $+REPLY )); then
     REPLY="${$(LC_ALL=C builtin type -w -- $1 2>/dev/null)#*: }"
   fi
+  _zsh_highlight_command_type_cache[(e)$1]=$REPLY
 }
 
 # Check whether the first argument is a redirection operator token.

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -68,7 +68,7 @@ _zsh_highlight_main_highlighter_predicate()
 # Helper to deal with tokens crossing line boundaries.
 _zsh_highlight_main_add_region_highlight() {
   integer start=$1 end=$2
-  local style=$3
+  shift 2
 
   # The calculation was relative to $PREBUFFER$BUFFER, but region_highlight is
   # relative to $BUFFER.
@@ -77,7 +77,7 @@ _zsh_highlight_main_add_region_highlight() {
 
   (( end < 0 )) && return # having end<0 would be a bug
   (( start < 0 )) && start=0 # having start<0 is normal with e.g. multiline strings
-  _zsh_highlight_add_highlight $start $end $style
+  _zsh_highlight_add_highlight $start $end "$@"
 }
 
 # Wrapper around 'type -w'.

--- a/highlighters/main/test-data/hashed-command.zsh
+++ b/highlighters/main/test-data/hashed-command.zsh
@@ -31,5 +31,5 @@ hash zsh_syntax_highlighting_hash=/doesnotexist
 BUFFER='zsh_syntax_highlighting_hash'
 
 expected_region_highlight=(
-  "1 28 hashed-command"
+  "1 28 hashed-command 'zsh/parameter cannot distinguish between hashed and command'"
 )

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -322,6 +322,7 @@ _zsh_highlight_preexec_hook()
 {
   typeset -g _ZSH_HIGHLIGHT_PRIOR_BUFFER=
   typeset -gi _ZSH_HIGHLIGHT_PRIOR_CURSOR=
+  _zsh_highlight_command_type_cache=()
 }
 autoload -U add-zsh-hook
 add-zsh-hook preexec _zsh_highlight_preexec_hook 2>/dev/null || {
@@ -333,3 +334,6 @@ zmodload zsh/parameter 2>/dev/null || true
 
 # Initialize the array of active highlighters if needed.
 [[ $#ZSH_HIGHLIGHT_HIGHLIGHTERS -eq 0 ]] && ZSH_HIGHLIGHT_HIGHLIGHTERS=(main) || true
+
+# Initialize command type cache
+typeset -A _zsh_highlight_command_type_cache


### PR DESCRIPTION
This pull-request improves z-sy-h performance by avoiding all forks.

Especially on Cygwin the improvement is extreme.

The only drawback so far seems to be that "hashed" commands cannot be distinguished from normal "commands" anymore -- which I think is very minor.

Anyways, this is more of a proof-of-concept.