### PR TITLE
Fix #302

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -93,6 +93,12 @@ _zsh_highlight_main__type() {
   LC_ALL=C builtin type -w -- $1 2>/dev/null
 }
 
+# Check whether the first argument is a redirection operator token.
+# Report result via the exit code.
+_zsh_highlight_main__is_redirection() {
+  [[ $1 == (<0-9>|)(\<|\>)* ]]
+}
+
 # Main syntax highlighting function.
 _zsh_highlight_main_highlighter()
 {
@@ -351,7 +357,7 @@ _zsh_highlight_main_highlighter()
                           else
                             style=unknown-token
                           fi
-                        elif [[ $arg == (<0-9>|)(\<|\>)* ]]; then
+                        elif _zsh_highlight_main__is_redirection $arg; then
                           # A '<' or '>', possibly followed by a digit
                           style=redirection
                           (( in_redirection=2 ))
@@ -421,7 +427,7 @@ _zsh_highlight_main_highlighter()
                    else
                      style=unknown-token
                    fi
-                 elif [[ $arg == (<0-9>|)(\<|\>)* ]]; then
+                 elif _zsh_highlight_main__is_redirection $arg; then
                    style=redirection
                    (( in_redirection=2 ))
                  else

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -96,7 +96,11 @@ _zsh_highlight_main__type() {
 # Check whether the first argument is a redirection operator token.
 # Report result via the exit code.
 _zsh_highlight_main__is_redirection() {
-  [[ $1 == (<0-9>|)(\<|\>)* ]]
+  # A redirection operator token:
+  # - starts with an optional single-digit number;
+  # - then, has a '<' or '>' character;
+  # - is not a process substitution [<(...) or >(...)].
+  [[ $1 == (<0-9>|)(\<|\>)* ]] && [[ $1 != (\<|\>)$'\x28'* ]]
 }
 
 # Main syntax highlighting function.

--- a/highlighters/main/test-data/redirection2.zsh
+++ b/highlighters/main/test-data/redirection2.zsh
@@ -1,0 +1,36 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2016 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+BUFFER='ls >(wc) | nl'
+
+expected_region_highlight=(
+  "1 2 command" # ls
+  "10 10 commandseparator" # |
+  "12 13 command 'issue #302'" # nl
+)

--- a/highlighters/main/test-data/redirection2.zsh
+++ b/highlighters/main/test-data/redirection2.zsh
@@ -32,5 +32,5 @@ BUFFER='ls >(wc) | nl'
 expected_region_highlight=(
   "1 2 command" # ls
   "10 10 commandseparator" # |
-  "12 13 command 'issue #302'" # nl
+  "12 13 command" # nl
 )


### PR DESCRIPTION
#302 is "Process substitution misparsed as redirection".  Test included.

Known issues:

- The file-local functions don't follow a consistent naming pattern: we have `_zsh_highlight_main_highlighter_*`, `_zsh_highlight_main_*`, and `_zsh_highlight_main__*`.