### PR TITLE
main-highlighter can be run as command

### DIFF
--- a/highlighters/main/parse.zsh
+++ b/highlighters/main/parse.zsh
@@ -1,0 +1,16 @@
+#!/bin/zsh
+
+source "../../zsh-syntax-highlighting.zsh"
+
+if [ -n "$1" ]; then
+    # Load from given file
+    PREBUFFER=""
+    BUFFER="$(<$1)"
+
+    _zsh_highlight_main_highlighter
+
+    # This output can be diffed to detect changes in operation 
+    print -rl -- "${region_highlight[@]}"
+else
+    echo "Usage: ./parse.zsh {file}"
+fi


### PR DESCRIPTION
I've added 4 blocks of code that make main-highlighter runnable as a command. This sounds bad, but I think it isn't. It's your call :)