### PR TITLE
'main': Try the "non-command word" codepath when a word may be either a command word or a non-command word.

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -273,6 +273,7 @@ _zsh_highlight_main_highlighter()
     # which add the entry early so escape sequences within the string override
     # the string's color.
     integer already_added=0
+    style=unknown-token
     if [[ $this_word == *':start:'* ]]; then
       in_array_assignment=false
       if [[ $arg == 'noglob' ]]; then
@@ -468,12 +469,16 @@ _zsh_highlight_main_highlighter()
                         ;;
       esac
      fi
-    else # $arg is a non-command word
+   fi
+   if (( ! already_added )) && [[ $style == unknown-token ]] && # not handled by the 'command word' codepath
+      { (( in_redirection )) || [[ $this_word == *':regular:'* ]] || [[ $this_word == *':sudo_opt:'* ]] || [[ $this_word == *':sudo_arg:'* ]] }
+   then # $arg is a non-command word
       case $arg in
         $'\x29') # subshell or end of array assignment
                  if $in_array_assignment; then
                    style=assign
                    in_array_assignment=false
+                   next_word+=':start:'
                  else
                    style=reserved-word
                  fi;;

--- a/highlighters/main/test-data/assign-array2.zsh
+++ b/highlighters/main/test-data/assign-array2.zsh
@@ -32,5 +32,5 @@ BUFFER='A=(hello world) ls'
 expected_region_highlight=(
   "1 3 assign" # A=(
   "15 15 assign" # )
-  "17 18 command 'issue #330'" # ls
+  "17 18 command" # ls
 )

--- a/highlighters/main/test-data/assign-array3.zsh
+++ b/highlighters/main/test-data/assign-array3.zsh
@@ -32,5 +32,5 @@ BUFFER='A=(hello world) b=42'
 expected_region_highlight=(
   "1 3 assign" # A=(
   "15 15 assign" # )
-  "17 20 assign 'issue #330'" # b=42
+  "17 20 assign" # b=42
 )

--- a/highlighters/main/test-data/assign-subshell.zsh
+++ b/highlighters/main/test-data/assign-subshell.zsh
@@ -32,5 +32,5 @@ BUFFER='(A=1)'
 expected_region_highlight=(
   "1 1 reserved-word" # (
   "2 4 assign" # A=1
-  "5 5 reserved-word 'issue #231'" # )
+  "5 5 reserved-word" # )
 )


### PR DESCRIPTION
Fixes #231.
Fixes #330.