### PR TITLE
Declare global variables

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -32,8 +32,8 @@
 0=${(%):-%N}
 if true; then
   # $0 is reliable
-  ZSH_HIGHLIGHT_VERSION=$(<"${0:A:h}"/.version)
-  ZSH_HIGHLIGHT_REVISION=$(<"${0:A:h}"/.revision-hash)
+  typeset -g ZSH_HIGHLIGHT_VERSION=$(<"${0:A:h}"/.version)
+  typeset -g ZSH_HIGHLIGHT_REVISION=$(<"${0:A:h}"/.revision-hash)
   if [[ $ZSH_HIGHLIGHT_REVISION == \$Format:* ]]; then
     # When running from a source tree without 'make install', $ZSH_HIGHLIGHT_REVISION
     # would be set to '$Format:%H$' literally.  That's an invalid value, and obtaining


### PR DESCRIPTION
This caused warnings with `setopt warn_create_global`