### PR TITLE
'brackets': Don't highlight corresponding bracket on accept-line

### DIFF
--- a/highlighters/brackets/brackets-highlighter.zsh
+++ b/highlighters/brackets/brackets-highlighter.zsh
@@ -40,7 +40,7 @@
 # Whether the brackets highlighter should be called or not.
 _zsh_highlight_highlighter_brackets_predicate()
 {
-  _zsh_highlight_cursor_moved || _zsh_highlight_buffer_modified
+  [[ $WIDGET == zle-line-finish ]] || _zsh_highlight_cursor_moved || _zsh_highlight_buffer_modified
 }
 
 # Brackets highlighting function.
@@ -85,11 +85,13 @@ _zsh_highlight_highlighter_brackets_paint()
     _zsh_highlight_add_highlight $((pos - 1)) $pos $style
   done
 
-  # If cursor is on a bracket, then highlight corresponding bracket, if any
-  pos=$((CURSOR + 1))
-  if [[ -n $levelpos[$pos] ]] && [[ -n $matching[$pos] ]]; then
-    local -i otherpos=$matching[$pos]
-    _zsh_highlight_add_highlight $((otherpos - 1)) $otherpos cursor-matchingbracket
+  # If cursor is on a bracket, then highlight corresponding bracket, if any.
+  if [[ $WIDGET != zle-line-finish ]]; then
+    pos=$((CURSOR + 1))
+    if [[ -n $levelpos[$pos] ]] && [[ -n $matching[$pos] ]]; then
+      local -i otherpos=$matching[$pos]
+      _zsh_highlight_add_highlight $((otherpos - 1)) $otherpos cursor-matchingbracket
+    fi
   fi
 }
 

--- a/highlighters/brackets/test-data/cursor-matchingbracket-line-finish.zsh
+++ b/highlighters/brackets/test-data/cursor-matchingbracket-line-finish.zsh
@@ -1,0 +1,37 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2016 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+WIDGET=zle-line-finish
+
+BUFFER=': $foo[bar]'
+CURSOR=6 # cursor is zero-based
+
+expected_region_highlight=(
+  "11 11 NONE"
+)


### PR DESCRIPTION
Makes sure that the corresponding bracket highlighting does not stay after accepting the line.

Similar to what the `main` and `cursor` highlighters do.