### PR TITLE
'main' / *_check_path: Precompute $#BUFFER and use it for speed gain

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -212,6 +212,7 @@ _zsh_highlight_highlighter_main_paint()
   local -a options_to_set # used in callees
   local buf="$PREBUFFER$BUFFER"
   integer len="${#buf}"
+  integer pure_buf_len=$(( len - ${#PREBUFFER} ))   # == $#BUFFER, used e.g. in *_check_path
 
   local braces_stack # "R" for round, "Q" for square, "Y" for curly
 
@@ -701,7 +702,7 @@ _zsh_highlight_main_highlighter_check_path()
   [[ ! -d ${expanded_path:h} ]] && return 1
 
   # If this word ends the buffer, check if it's the prefix of a valid path.
-  if [[ ${BUFFER[1]} != "-" && ${#BUFFER} == $end_pos ]] &&
+  if [[ ${BUFFER[1]} != "-" && $pure_buf_len == $end_pos ]] &&
      [[ $WIDGET != zle-line-finish ]]; then
     local -a tmp
     tmp=( ${expanded_path}*(N) )


### PR DESCRIPTION
Running main highlighter on itself (both runs are on the optimized
version):

- clean (8 runs, last 3 noted):
1.7007670000
1.7330720000
1.7038810000

- optimized (8 runs, last 3 noted):
1.5007230000
1.5142960000
1.4973320000

Average difference: 0.208456

When parsing main-highlighter with itself, the *_check_path function is
called 426 times. Note that there are 686 region_highlight resulting
entries.