### PR TITLE
Code and test changes for running with NO_UNSET, as per issue 398

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test:
 	for test in highlighters/*; do \
 		if [ -d $$test/test-data ]; then \
 			echo "Running test $${test##*/}"; \
-			$(ZSH) -f tests/test-highlighting.zsh "$${test##*/}"; \
+			$(ZSH) -fu tests/test-highlighting.zsh "$${test##*/}"; \
 			: $$(( result |= $$? )); \
 		fi \
 	done; \

--- a/highlighters/brackets/brackets-highlighter.zsh
+++ b/highlighters/brackets/brackets-highlighter.zsh
@@ -40,7 +40,7 @@
 # Whether the brackets highlighter should be called or not.
 _zsh_highlight_highlighter_brackets_predicate()
 {
-  [[ $WIDGET == zle-line-finish ]] || _zsh_highlight_cursor_moved || _zsh_highlight_buffer_modified
+  [[ ${WIDGET-} == zle-line-finish ]] || _zsh_highlight_cursor_moved || _zsh_highlight_buffer_modified
 }
 
 # Brackets highlighting function.
@@ -59,7 +59,7 @@ _zsh_highlight_highlighter_brackets_paint()
         lastoflevel[$level]=$pos
         ;;
       [")]}"])
-        matchingpos=$lastoflevel[$level]
+        matchingpos=${lastoflevel[$level]-}
         levelpos[$pos]=$((level--))
 	if _zsh_highlight_brackets_match $matchingpos $pos; then
           matching[$matchingpos]=$pos
@@ -86,9 +86,9 @@ _zsh_highlight_highlighter_brackets_paint()
   done
 
   # If cursor is on a bracket, then highlight corresponding bracket, if any.
-  if [[ $WIDGET != zle-line-finish ]]; then
+  if [[ ${WIDGET-} != zle-line-finish ]]; then
     pos=$((CURSOR + 1))
-    if [[ -n $levelpos[$pos] ]] && [[ -n $matching[$pos] ]]; then
+    if [[ -n ${levelpos[$pos]-} && -n $matching[$pos] ]]; then
       local -i otherpos=$matching[$pos]
       _zsh_highlight_add_highlight $((otherpos - 1)) $otherpos cursor-matchingbracket
     fi
@@ -98,7 +98,7 @@ _zsh_highlight_highlighter_brackets_paint()
 # Helper function to differentiate type 
 _zsh_highlight_brackets_match()
 {
-  case $BUFFER[$1] in
+  case ${BUFFER[$1]-} in
     \() [[ $BUFFER[$2] == \) ]];;
     \[) [[ $BUFFER[$2] == \] ]];;
     \{) [[ $BUFFER[$2] == \} ]];;

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -95,7 +95,7 @@ _zsh_highlight_main_add_region_highlight() {
 
   # The calculation was relative to $PREBUFFER$BUFFER, but region_highlight is
   # relative to $BUFFER.
-  (( start -= $#PREBUFFER ))
+  (( start -= $#PREBUFFER )) || :
   (( end -= $#PREBUFFER ))
 
   (( end < 0 )) && return # having end<0 would be a bug
@@ -384,7 +384,7 @@ _zsh_highlight_highlighter_main_paint()
       else
           integer offset=0
       fi
-      ((start_pos+=offset))
+      ((start_pos+=offset)) || :
       ((end_pos=$start_pos+${#arg}))
     fi
 

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -146,8 +146,8 @@ _zsh_highlight_main__type() {
       REPLY=none
     fi
   fi
-  if ! (( $+REPLY )); then
-    REPLY="${$(LC_ALL=C builtin type -w -- $1 2>/dev/null)#*: }"
+  if ! (( $+REPLY )); then	# below will frequently trigger ERR trap without || :
+    REPLY="${$(LC_ALL=C builtin type -w -- $1 2>/dev/null || :)#*: }"
   fi
   if (( $+_zsh_highlight_main__command_type_cache )); then
     _zsh_highlight_main__command_type_cache[(e)$1]=$REPLY

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -214,7 +214,7 @@ _zsh_highlight_highlighter_main_paint()
     integer multi_func_def=0
   fi
   emulate -L zsh
-  setopt localoptions extendedglob bareglobqual
+  setopt localoptions extendedglob bareglobqual #xtrace
 
   # At the PS3 prompt and in vared, highlight nothing.
   #
@@ -537,7 +537,9 @@ _zsh_highlight_highlighter_main_paint()
                             style=alias
                             _zsh_highlight_main__resolve_alias $arg
                             local alias_target="$REPLY"
-                            [[ -n ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$alias_target"} && -z ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$arg"} ]] && ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS+=($arg)
+                            [[ -n ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$alias_target"}
+                            && -z ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$arg"} ]] &&
+                                ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS+=($arg) || :
                           fi
                         }
                         ;;
@@ -684,7 +686,7 @@ _zsh_highlight_highlighter_main_paint()
     fi
     if ! (( already_added )); then
       _zsh_highlight_main_add_region_highlight $start_pos $end_pos $style
-      [[ $style == path || $style == path_prefix ]] && _zsh_highlight_main_highlighter_highlight_path_separators
+      [[ $style == path || $style == path_prefix ]] && _zsh_highlight_main_highlighter_highlight_path_separators || :
     fi
     if [[ -n ${(M)ZSH_HIGHLIGHT_TOKENS_COMMANDSEPARATOR:#"$arg"} ]]; then
       if [[ $arg == ';' ]] && $in_array_assignment; then

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -58,7 +58,7 @@
 _zsh_highlight_highlighter_main_predicate()
 {
   # may need to remove path_prefix highlighting when the line ends
-  [[ $WIDGET == zle-line-finish ]] || _zsh_highlight_buffer_modified
+  [[ ${WIDGET-} == zle-line-finish ]] || _zsh_highlight_buffer_modified
 }
 
 # Helper to deal with tokens crossing line boundaries.

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -95,7 +95,7 @@ _zsh_highlight_main_add_region_highlight() {
 
   # The calculation was relative to $PREBUFFER$BUFFER, but region_highlight is
   # relative to $BUFFER.
-  (( start -= $#PREBUFFER )) || :
+  (( start -= $#PREBUFFER ))
   (( end -= $#PREBUFFER ))
 
   (( end < 0 )) && return # having end<0 would be a bug
@@ -146,8 +146,8 @@ _zsh_highlight_main__type() {
       REPLY=none
     fi
   fi
-  if ! (( $+REPLY )); then	# below will frequently trigger ERR trap without || :
-    REPLY="${$(LC_ALL=C builtin type -w -- $1 2>/dev/null || :)#*: }"
+  if ! (( $+REPLY )); then
+    REPLY="${$(LC_ALL=C builtin type -w -- $1 2>/dev/null)#*: }"
   fi
   if (( $+_zsh_highlight_main__command_type_cache )); then
     _zsh_highlight_main__command_type_cache[(e)$1]=$REPLY
@@ -214,7 +214,7 @@ _zsh_highlight_highlighter_main_paint()
     integer multi_func_def=0
   fi
   emulate -L zsh
-  setopt localoptions extendedglob bareglobqual #xtrace
+  setopt localoptions extendedglob bareglobqual
 
   # At the PS3 prompt and in vared, highlight nothing.
   #
@@ -384,7 +384,7 @@ _zsh_highlight_highlighter_main_paint()
       else
           integer offset=0
       fi
-      ((start_pos+=offset)) || :
+      ((start_pos+=offset))
       ((end_pos=$start_pos+${#arg}))
     fi
 
@@ -537,9 +537,7 @@ _zsh_highlight_highlighter_main_paint()
                             style=alias
                             _zsh_highlight_main__resolve_alias $arg
                             local alias_target="$REPLY"
-                            [[ -n ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$alias_target"}
-                            && -z ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$arg"} ]] &&
-                                ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS+=($arg) || :
+                            [[ -n ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$alias_target"} && -z ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$arg"} ]] && ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS+=($arg)
                           fi
                         }
                         ;;
@@ -686,7 +684,7 @@ _zsh_highlight_highlighter_main_paint()
     fi
     if ! (( already_added )); then
       _zsh_highlight_main_add_region_highlight $start_pos $end_pos $style
-      [[ $style == path || $style == path_prefix ]] && _zsh_highlight_main_highlighter_highlight_path_separators || :
+      [[ $style == path || $style == path_prefix ]] && _zsh_highlight_main_highlighter_highlight_path_separators
     fi
     if [[ -n ${(M)ZSH_HIGHLIGHT_TOKENS_COMMANDSEPARATOR:#"$arg"} ]]; then
       if [[ $arg == ';' ]] && $in_array_assignment; then

--- a/tests/test-highlighting.zsh
+++ b/tests/test-highlighting.zsh
@@ -56,7 +56,7 @@ zmodload zsh/zle
 # Overwrite _zsh_highlight_add_highlight so we get the key itself instead of the style
 _zsh_highlight_add_highlight()
 {
-  region_highlight+=("$1 $2 $3")
+  region_highlight+=("$1 $2 ${3-}")
 }
 
 # Activate the highlighter.
@@ -96,7 +96,7 @@ run_test_internal() {
       (( --end )) # convert to closed range, like expected_region_highlight
       (( ++start, ++end )) # region_highlight is 0-indexed; expected_region_highlight is 1-indexed
       for j in {$start..$end}; do
-        observed_result[$j]=$highlight_zone[3]
+        observed_result[$j]=${highlight_zone[3]-}
       done
     else
       # noop range; ignore.
@@ -115,10 +115,10 @@ run_test_internal() {
     local desc="[$start,$end] «${BUFFER[$start,$end]//'#'/♯}»"
     # Match the emptiness of observed_result if no highlighting is expected
     [[ $highlight_zone[3] == NONE ]] && highlight_zone[3]=
-    [[ -n "$highlight_zone[4]" ]] && todo="# TODO $highlight_zone[4]"
+    [[ -n ${highlight_zone[4]-} ]] && todo="# TODO $highlight_zone[4]"
     for j in {$start..$end}; do
-      if [[ "$observed_result[$j]" != "$highlight_zone[3]" ]]; then
-        print -r -- "not ok $i - $desc - expected ${(qqq)highlight_zone[3]}, observed ${(qqq)observed_result[$j]}. $todo"
+      if [[ ${observed_result[$j]-} != $highlight_zone[3] ]]; then
+        print -r -- "not ok $i - $desc - expected ${(qqq)highlight_zone[3]}, observed ${(qqq)observed_result[$j]-}. $todo"
         continue 2
       fi
     done
@@ -162,7 +162,7 @@ run_test() {
 
 # Set up results_filter
 local results_filter
-if [[ $QUIET == y ]]; then
+if [[ ${QUIET-} == y ]]; then
   if type -w perl >/dev/null; then
     results_filter=${0:A:h}/tap-filter
   else

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -308,16 +308,13 @@ then
   }
   _zsh_highlight_bind_widgets(){}
 
-  local prevunsetstate=
-  [[ -o unset ]] || prevunsetstate=NO_
-  setopt localoptions UNSET	# for following two add-zle-hook-widget calls...
-  # TODO: figure out why only 5.3 with no_unset gives following error
-  # add-zle-hook-widget:84: widgets[$hook]: parameter not set
-
-  add-zle-hook-widget zle-line-pre-redraw _zsh_highlight
-  add-zle-hook-widget zle-line-finish _zsh_highlight__zle-line-finish
-
-  setopt ${prevunsetstate}UNSET	# put back as before
+  # This is for 5.3 before about 5.3.2, or whenever add-zle-hook-widget
+  # in zsh source is modified to work with nounset in the calling scope.
+  () {
+	setopt localoptions UNSET
+	add-zle-hook-widget zle-line-pre-redraw _zsh_highlight
+	add-zle-hook-widget zle-line-finish _zsh_highlight__zle-line-finish
+  }
 else
   # Rebind all ZLE widgets to make them invoke _zsh_highlights.
   _zsh_highlight_bind_widgets()

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -317,7 +317,7 @@ then
   add-zle-hook-widget zle-line-pre-redraw _zsh_highlight
   add-zle-hook-widget zle-line-finish _zsh_highlight__zle-line-finish
 
-  setopt noxtrace ${prevunsetstate}UNSET	# put back as before
+  setopt ${prevunsetstate}UNSET	# put back as before
 else
   # Rebind all ZLE widgets to make them invoke _zsh_highlights.
   _zsh_highlight_bind_widgets()

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -66,7 +66,7 @@ _zsh_highlight()
   fi
 
 # Did a couple of tweaks to highlighters/main/main-highlighter.zsh
-# to prevent need for following, though there'll surely be others.
+# to prevent need for following, though there'll surely be other areas.
 # setopt localtraps
 # unfunction TRAPZERR
   setopt localoptions noksharrays warncreateglobal
@@ -171,6 +171,9 @@ _zsh_highlight()
 _zsh_highlight_apply_zle_highlight() {
   local entry="$1" default="$2"
   integer first="$3" second="$4"
+
+  setopt localoptions unset	# seems to be the accessing the array entry
+# rather than ${entry-} that aborts otherwise
 
   # read the relevant entry from zle_highlight
   local region="${zle_highlight[(r)${entry}:*]}"

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -104,7 +104,7 @@ _zsh_highlight()
 
   # Remove all highlighting in isearch, so that only the underlining done by zsh itself remains.
   # For details see FAQ entry 'Why does syntax highlighting not work while searching history?'.
-  if [[ $WIDGET == zle-isearch-update ]] && ! (( $+ISEARCHMATCH_ACTIVE )); then
+  if [[ ${WIDGET-} == zle-isearch-update ]] && ! (( $+ISEARCHMATCH_ACTIVE )); then
     region_highlight=()
     return $ret
   fi
@@ -118,7 +118,7 @@ _zsh_highlight()
   [[ -n ${ZSH_HIGHLIGHT_MAXLENGTH:-} ]] && [[ $#BUFFER -gt $ZSH_HIGHLIGHT_MAXLENGTH ]] && return $ret
 
   # Do not highlight if there are pending inputs (copy/paste).
-  [[ $PENDING -gt 0 ]] && return $ret
+  [[ ${PENDING-} -gt 0 ]] && return $ret
 
   # Reset region highlight to build it from scratch
   typeset -ga region_highlight
@@ -198,7 +198,7 @@ _zsh_highlight()
 
   } always {
     typeset -g _ZSH_HIGHLIGHT_PRIOR_BUFFER="$BUFFER"
-    typeset -gi _ZSH_HIGHLIGHT_PRIOR_CURSOR=$CURSOR
+    typeset -gi _ZSH_HIGHLIGHT_PRIOR_CURSOR=${CURSOR-}
   }
 }
 
@@ -213,10 +213,8 @@ _zsh_highlight_apply_zle_highlight() {
   local entry="$1" default="$2"
   integer first="$3" second="$4"
 
-  setopt localoptions unset	# Is it bug or feature that nounset will often abort this function?
-
   # read the relevant entry from zle_highlight
-  local region="${zle_highlight[(r)${entry}:*]}"
+  local region="${zle_highlight[(r)${entry}:*]-}"
 
   if [[ -z "$region" ]]; then
     # entry not specified at all, use default value
@@ -261,7 +259,7 @@ _zsh_highlight_buffer_modified()
 # Returns 0 if the cursor has moved since _zsh_highlight was last called.
 _zsh_highlight_cursor_moved()
 {
-  [[ -n $CURSOR ]] && [[ -n ${_ZSH_HIGHLIGHT_PRIOR_CURSOR-} ]] && (($_ZSH_HIGHLIGHT_PRIOR_CURSOR != $CURSOR))
+  [[ -n ${CURSOR-} && -n ${_ZSH_HIGHLIGHT_PRIOR_CURSOR-} ]] && (($_ZSH_HIGHLIGHT_PRIOR_CURSOR != $CURSOR))
 }
 
 # Add a highlight defined by ZSH_HIGHLIGHT_STYLES.
@@ -309,8 +307,17 @@ then
     } "$@"
   }
   _zsh_highlight_bind_widgets(){}
+
+  local prevunsetstate=
+  [[ -o unset ]] || prevunsetstate=NO_
+  setopt localoptions UNSET	# for following two add-zle-hook-widget calls...
+  # TODO: figure out why only 5.3 with no_unset gives following error
+  # add-zle-hook-widget:84: widgets[$hook]: parameter not set
+
   add-zle-hook-widget zle-line-pre-redraw _zsh_highlight
   add-zle-hook-widget zle-line-finish _zsh_highlight__zle-line-finish
+
+  setopt noxtrace ${prevunsetstate}UNSET	# put back as before
 else
   # Rebind all ZLE widgets to make them invoke _zsh_highlights.
   _zsh_highlight_bind_widgets()
@@ -340,7 +347,7 @@ else
   
     local cur_widget
     for cur_widget in $widgets_to_bind; do
-      case $widgets[$cur_widget] in
+      case ${widgets[$cur_widget]-} in
   
         # Already rebound event: do nothing.
         user:_zsh_highlight_widget_*);;
@@ -367,7 +374,7 @@ else
   
         # Incomplete or nonexistent widget: Bind to z-sy-h directly.
         *) 
-           if [[ $cur_widget == zle-* ]] && [[ -z $widgets[$cur_widget] ]]; then
+           if [[ $cur_widget == zle-* && -z ${widgets[$cur_widget]-} ]]; then
              _zsh_highlight_widget_${cur_widget}() { :; _zsh_highlight }
              zle -N $cur_widget _zsh_highlight_widget_$cur_widget
            else

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -109,11 +109,8 @@ _zsh_highlight()
     return $ret
   fi
 
-# Did a couple of tweaks to highlighters/main/main-highlighter.zsh
-# to prevent need for following, though there'll surely be other areas.
-# setopt localtraps
-# unfunction TRAPZERR
-  setopt localoptions noksharrays warncreateglobal
+  setopt localoptions warncreateglobal
+  setopt localoptions noksharrays
   local REPLY # don't leak $REPLY into global scope
 
   # Do not highlight if there are more than 300 chars in the buffer. It's most
@@ -216,8 +213,7 @@ _zsh_highlight_apply_zle_highlight() {
   local entry="$1" default="$2"
   integer first="$3" second="$4"
 
-  setopt localoptions unset	# seems to be the accessing the array entry
-# rather than ${entry-} that aborts otherwise
+  setopt localoptions unset	# Is it bug or feature that nounset will often abort this function?
 
   # read the relevant entry from zle_highlight
   local region="${zle_highlight[(r)${entry}:*]}"
@@ -402,7 +398,7 @@ _zsh_highlight_load_highlighters()
   for highlighter_dir ($1/*/); do
     highlighter="${highlighter_dir:t}"
     [[ -f "$highlighter_dir/${highlighter}-highlighter.zsh" ]] &&
-      source "$highlighter_dir/${highlighter}-highlighter.zsh"
+      . "$highlighter_dir/${highlighter}-highlighter.zsh"
     if type "_zsh_highlight_highlighter_${highlighter}_paint" &> /dev/null &&
        type "_zsh_highlight_highlighter_${highlighter}_predicate" &> /dev/null;
     then

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -255,7 +255,7 @@ _zsh_highlight_call_widget()
 # Rebind all ZLE widgets to make them invoke _zsh_highlights.
 _zsh_highlight_bind_widgets()
 {
-  setopt localoptions noksharrays
+  setopt localoptions noksharrays unset
   typeset -F SECONDS
   local prefix=orig-s$SECONDS-r$RANDOM # unique each time, in case we're sourced more than once
 
@@ -280,7 +280,7 @@ _zsh_highlight_bind_widgets()
 
   local cur_widget
   for cur_widget in $widgets_to_bind; do
-    case $widgets[$cur_widget] in
+    case $widgets[$cur_widget] in	# requires no_unset be unset
 
       # Already rebound event: do nothing.
       user:_zsh_highlight_widget_*);;

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -65,8 +65,11 @@ _zsh_highlight()
     return $ret
   fi
 
-  setopt localoptions warncreateglobal
-  setopt localoptions noksharrays
+# Did a couple of tweaks to highlighters/main/main-highlighter.zsh
+# to prevent need for following, thut there'll surely be others.
+# setopt localtraps
+# unfunction TRAPZERR
+  setopt localoptions noksharrays warncreateglobal
   local REPLY # don't leak $REPLY into global scope
 
   # Do not highlight if there are more than 300 chars in the buffer. It's most

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -66,7 +66,7 @@ _zsh_highlight()
   fi
 
 # Did a couple of tweaks to highlighters/main/main-highlighter.zsh
-# to prevent need for following, thut there'll surely be others.
+# to prevent need for following, though there'll surely be others.
 # setopt localtraps
 # unfunction TRAPZERR
   setopt localoptions noksharrays warncreateglobal
@@ -337,7 +337,7 @@ _zsh_highlight_load_highlighters()
   for highlighter_dir ($1/*/); do
     highlighter="${highlighter_dir:t}"
     [[ -f "$highlighter_dir/${highlighter}-highlighter.zsh" ]] &&
-      . "$highlighter_dir/${highlighter}-highlighter.zsh"
+      source "$highlighter_dir/${highlighter}-highlighter.zsh"
     if type "_zsh_highlight_highlighter_${highlighter}_paint" &> /dev/null &&
        type "_zsh_highlight_highlighter_${highlighter}_predicate" &> /dev/null;
     then


### PR DESCRIPTION
I tested this in all of 5.07, 5.2, and 5.3 -- test results look to be same as before, and quiet-test is silent. To get NO_UNSET I just added -u to the Makefile rather than alter test scripts for it.

I suspect this may have uncovered a related bug with 5.3 only; see the comments around line 313 in the zsh-syntax-highlighting.zsh file, and let me know if you figure out a better fix.
