### PR TITLE
Use zsh 5.4's WARN_NESTED_VAR, convert driver to anonymous function

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -36,8 +36,9 @@ local zsh_highlight__aliases="`builtin alias -Lm '[^+]*'`"
 # Hence, we exclude them from unaliasing:
 builtin unalias -m '[^+]*'
 
+# Set the 5.4-to-be WARN_NESTED_VAR option if it's available.
 emulate -L zsh
-setopt localoptions warncreateglobal
+setopt localoptions warncreateglobal ${(k)options[(I)warnnestedvar]}
 
 # Set $0 to the expected value, regardless of functionargzero.
 0=${(%):-%N}
@@ -49,7 +50,7 @@ if true; then
     # When running from a source tree without 'make install', $ZSH_HIGHLIGHT_REVISION
     # would be set to '$Format:%H$' literally.  That's an invalid value, and obtaining
     # the valid value (via `git rev-parse HEAD`, as Makefile does) might be costly, so:
-    ZSH_HIGHLIGHT_REVISION=HEAD
+    typeset -g ZSH_HIGHLIGHT_REVISION=HEAD
   fi
 fi
 
@@ -401,7 +402,7 @@ zmodload zsh/parameter 2>/dev/null || true
 autoload -U is-at-least
 
 # Initialize the array of active highlighters if needed.
-[[ $#ZSH_HIGHLIGHT_HIGHLIGHTERS -eq 0 ]] && ZSH_HIGHLIGHT_HIGHLIGHTERS=(main)
+[[ $#ZSH_HIGHLIGHT_HIGHLIGHTERS -eq 0 ]] && ZSH_HIGHLIGHT_HIGHLIGHTERS[1]=main
 
 # Restore the aliases we unned
 eval "$zsh_highlight__aliases"

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -29,7 +29,7 @@
 # -------------------------------------------------------------------------------------------------
 
 # First of all, ensure predictable parsing.
-local zsh_highlight__aliases="`builtin alias -Lm '[^+]*'`"
+local zsh_highlight__aliases="$(builtin alias -Lm '[^+]*')"
 # In zsh <= 5.2, `alias -L` emits aliases that begin with a plus sign ('alias -- +foo=42')
 # them without a '--' guard, so they don't round trip.
 #

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -1,3 +1,4 @@
+() { # that's here to make the line numbers in errors match the file line numbers.
 # -------------------------------------------------------------------------------------------------
 # Copyright (c) 2010-2016 zsh-syntax-highlighting contributors
 # All rights reserved.
@@ -28,12 +29,14 @@
 # -------------------------------------------------------------------------------------------------
 
 # First of all, ensure predictable parsing.
-zsh_highlight__aliases=`builtin alias -Lm '[^+]*'`
+local zsh_highlight__aliases="`builtin alias -Lm '[^+]*'`"
 # In zsh <= 5.2, `alias -L` emits aliases that begin with a plus sign ('alias -- +foo=42')
 # them without a '--' guard, so they don't round trip.
 #
 # Hence, we exclude them from unaliasing:
 builtin unalias -m '[^+]*'
+
+setopt localoptions warncreateglobal
 
 # Set $0 to the expected value, regardless of functionargzero.
 0=${(%):-%N}
@@ -405,3 +408,6 @@ builtin unset zsh_highlight__aliases
 
 # Set $?.
 true
+
+# End anonymous function
+}

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -36,6 +36,7 @@ local zsh_highlight__aliases="`builtin alias -Lm '[^+]*'`"
 # Hence, we exclude them from unaliasing:
 builtin unalias -m '[^+]*'
 
+emulate -L zsh
 setopt localoptions warncreateglobal
 
 # Set $0 to the expected value, regardless of functionargzero.


### PR DESCRIPTION
If this is merged before upstream 5.4 is released then update #412 at merge time.