### PR TITLE
workaround for PAT_STATIC bug in zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,13 @@ syntax highlighting.
 
 ### Does syntax highlighting work during incremental history search?
 
-Highlighting the command line during an incremental history search
-(with the `history-incremental-search-backward` widget, which is
-bound by default to <kbd>Ctrl+R</kbd> in zsh's emacs keymap) requires zsh 5.3
-or newer.
+Yes!
+
+If you're using `history-incremental-search-backward` (by default bound to <kbd>Ctrl+R</kbd>
+in zsh's emacs keymap) then it works with _zsh version 5.3 and newer_.
+
+If you're using `history-incremental-pattern-search-backward`, then syntax highlighting works
+in _zsh 5.3.2 and newer_ due to [a bug in zsh](http://www.zsh.org/cgi-bin/mla/redirect?WORKERNUMBER=40285).
 
 Under zsh 5.2 and older, the zsh-default [underlining][zshzle-Character-Highlighting]
 of the matched portion of the buffer remains available, but zsh-syntax-highlighting's

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -53,6 +53,15 @@ fi
 # Core highlighting update system
 # -------------------------------------------------------------------------------------------------
 
+# Use workaround for bug in ZSH?
+# zsh-users/zsh@48cadf4 http://www.zsh.org/mla/workers//2017/msg00034.html
+autoload -U is-at-least
+if is-at-least 5.3.2; then
+  zsh_highlight__pat_static_bug=false
+else
+  zsh_highlight__pat_static_bug=true
+fi
+
 # Array declaring active highlighters names.
 typeset -ga ZSH_HIGHLIGHT_HIGHLIGHTERS
 
@@ -67,7 +76,9 @@ _zsh_highlight()
 
   # Remove all highlighting in isearch, so that only the underlining done by zsh itself remains.
   # For details see FAQ entry 'Why does syntax highlighting not work while searching history?'.
-  if [[ $WIDGET == zle-isearch-update ]] && ! (( $+ISEARCHMATCH_ACTIVE )); then
+  # This disables highlighting during isearch (for reasons explained in README.md) unless zsh is new enough
+  # and doesn't have the 5.3.1 bug
+  if [[ $WIDGET == zle-isearch-update ]] && { $zsh_highlight__pat_static_bug || ! (( $+ISEARCHMATCH_ACTIVE )) }; then
     region_highlight=()
     return $ret
   fi
@@ -393,8 +404,6 @@ add-zsh-hook preexec _zsh_highlight_preexec_hook 2>/dev/null || {
 
 # Load zsh/parameter module if available
 zmodload zsh/parameter 2>/dev/null || true
-
-autoload -U is-at-least
 
 # Initialize the array of active highlighters if needed.
 [[ $#ZSH_HIGHLIGHT_HIGHLIGHTERS -eq 0 ]] && ZSH_HIGHLIGHT_HIGHLIGHTERS=(main)


### PR DESCRIPTION
ZSH versions less than 5.3.2 (or 5.4) have a bug that prevents
`history-incremental-pattern-search-backward` for working
correctly (the history stops searching after the first found item).

Closes #407