### PR TITLE
Fix zcompile error with zsh 5.4

### DIFF
--- a/highlighters/main/test-data/function.zsh
+++ b/highlighters/main/test-data/function.zsh
@@ -27,10 +27,10 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
-cd() {
+function cd {
   builtin cd "$@"
 }
-ls() {
+function ls {
   command ls "$@"
 }
 BUFFER='cd;ls'


### PR DESCRIPTION
Error is:

    $ zcompile highlighters/main/test-data/function.zsh
    zsh: defining function based on alias `ls'
    zsh: parse error near `()'
    zcompile: can't read file: highlighters/main/test-data/function.zsh

View `Incompatibilities since 5.3.1` in https://github.com/zsh-users/zsh/blob/bb218704d27bcca9aa4426296dcd5c13d58b330a/README