### PR TITLE
Fixes to be NOUNSET clean

### DIFF
--- a/tests/test-highlighting.zsh
+++ b/tests/test-highlighting.zsh
@@ -135,12 +135,16 @@ run_test_internal() {
     integer start=$highlight_zone[1] end=$highlight_zone[2]
     # Escape # as ♯ since the former is illegal in the 'description' part of TAP output
     local desc="[$start,$end] «${BUFFER[$start,$end]//'#'/♯}»"
-    # Match the emptiness of observed_result if no highlighting is expected
-    [[ $highlight_zone[3] == NONE ]] && highlight_zone[3]=
     (( $+highlight_zone[4] )) && todo="# TODO $highlight_zone[4]"
     for j in {$start..$end}; do
-      if [[ "$observed_result[$j]" != "$highlight_zone[3]" ]]; then
-        print -r -- "not ok $i - $desc - expected ${(qqq)highlight_zone[3]}, observed ${(qqq)observed_result[$j]}. $todo"
+      if
+	if [[ $highlight_zone[3] == NONE ]]; then
+	  (( $+observed_result[$j] ))
+	else
+	  [[ "$observed_result[$j]" != "$highlight_zone[3]" ]]
+	fi
+      then
+        print -r -- "not ok $i - $desc - expected ${(qqq)highlight_zone[3]}, observed ${(qqq)observed_result[$j]-NONE}. $todo"
         continue 2
       fi
     done

--- a/tests/test-highlighting.zsh
+++ b/tests/test-highlighting.zsh
@@ -103,6 +103,9 @@ run_test_internal() {
   # Check the data declares $expected_region_highlight.
   (( ${#expected_region_highlight} == 0 )) && { echo >&2 "Bail out! 'expected_region_highlight' is not declared or empty."; return 1; }
 
+  # Set sane defaults for ZLE variables
+  : ${CURSOR=$#BUFFER} ${PENDING=0} ${WIDGET=z-sy-h-test-harness-test-widget}
+
   # Process the data.
   region_highlight=()
   _zsh_highlight

--- a/tests/test-highlighting.zsh
+++ b/tests/test-highlighting.zsh
@@ -29,6 +29,8 @@
 # -------------------------------------------------------------------------------------------------
 
 
+setopt NOUNSET
+
 # Check an highlighter was given as argument.
 [[ -n "$1" ]] || {
   echo >&2 "Bail out! You must provide the name of a valid highlighter as argument."

--- a/tests/test-highlighting.zsh
+++ b/tests/test-highlighting.zsh
@@ -49,7 +49,7 @@
 
 # Set up results_filter
 local results_filter
-if [[ $QUIET == y ]]; then
+if [[ ${QUIET-} == y ]]; then
   if type -w perl >/dev/null; then
     results_filter=${0:A:h}/tap-filter
   else

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -188,7 +188,7 @@ _zsh_highlight_apply_zle_highlight() {
   integer first="$3" second="$4"
 
   # read the relevant entry from zle_highlight
-  local region="${zle_highlight[(r)${entry}:*]}"
+  local region="${zle_highlight[(r)${entry}:*]-}"
 
   if [[ -z "$region" ]]; then
     # entry not specified at all, use default value


### PR DESCRIPTION
There are still a few more changes required (on my nounset-full branch) to default CURSOR, PENDING, and WIDGET to empty; but they may be better fixed upstream in zsh.