### PR TITLE
Highlight precommands and correct expansions order

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -214,7 +214,7 @@ _zsh_highlight_highlighter_main_paint()
   fi
 
   ## Variable declarations and initializations
-  local start_pos=0 end_pos highlight_glob=true arg style
+  local start_pos=0 end_pos highlight_glob=true arg arg_raw style
   local in_array_assignment=false # true between 'a=(' and the matching ')'
   typeset -a ZSH_HIGHLIGHT_TOKENS_COMMANDSEPARATOR
   typeset -a ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS
@@ -322,6 +322,9 @@ _zsh_highlight_highlighter_main_paint()
     args=(${(z)buf})
   fi
   for arg in $args; do
+    # Save an unmunged copy of the current word.
+    arg_raw="$arg"
+
     # Initialize $next_word.
     if (( in_redirection )); then
       (( --in_redirection ))
@@ -432,6 +435,30 @@ _zsh_highlight_highlighter_main_paint()
       fi
     fi
 
+    # Expand aliases.
+    # TODO: this should be done iteratively, e.g., 'alias x=y y=z z=w\n x' 
+    #       And then the entire 'alias' branch of the 'case' statement should
+    #       be done here.
+    () {
+      # TODO: path expansion should happen _after_ alias expansion
+      _zsh_highlight_main_highlighter_expand_path $arg
+      local expanded_arg="$REPLY"
+      _zsh_highlight_main__type ${expanded_arg}
+    }
+    local res="$REPLY"
+    if [[ $res == "alias" ]]; then
+      _zsh_highlight_main__resolve_alias $arg
+      () {
+        # Use a temporary array to ensure the subscript is interpreted as
+        # an array subscript, not as a scalar subscript
+        local -a reply
+        # TODO: the ${interactive_comments+set} path needs to skip comments; see test-data/alias-comment1.zsh
+        reply=( ${interactive_comments-${(z)REPLY}}
+                ${interactive_comments+${(zZ+c+)REPLY}} )
+        arg=$reply[1]
+      }
+    fi
+
     # Special-case the first word after 'sudo'.
     if (( ! in_redirection )); then
       if [[ $this_word == *':sudo_opt:'* ]] && [[ $arg != -* ]]; then
@@ -472,10 +499,6 @@ _zsh_highlight_highlighter_main_paint()
       next_word+=':sudo_opt:'
       next_word+=':start:'
      else
-      _zsh_highlight_main_highlighter_expand_path $arg
-      local expanded_arg="$REPLY"
-      _zsh_highlight_main__type ${expanded_arg}
-      local res="$REPLY"
       () {
         # Special-case: command word is '$foo', like that, without braces or anything.
         #
@@ -548,8 +571,9 @@ _zsh_highlight_highlighter_main_paint()
                         ;;
         'suffix alias') style=suffix-alias;;
         alias)          () {
+                          # Make sure to use $arg_raw here, rather than $arg.
                           integer insane_alias
-                          case $arg in
+                          case $arg_raw in
                             # Issue #263: aliases with '=' on their LHS.
                             #
                             # There are three cases:
@@ -563,12 +587,13 @@ _zsh_highlight_highlighter_main_paint()
                           esac
                           if (( insane_alias )); then
                             style=unknown-token
+                          # Calling 'type' again; since __type memoizes the answer, this call is just a hash lookup.
+                          elif _zsh_highlight_main__type "$arg"; [[ $REPLY == 'none' ]]; then
+                            style=unknown-token
                           else
                             # The common case.
                             style=alias
-                            _zsh_highlight_main__resolve_alias $arg
-                            local alias_target="$REPLY"
-                            [[ -n ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$alias_target"} && -z ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$arg"} ]] && ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS+=($arg)
+                            [[ -n ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$arg"} && -z ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$arg_raw"} ]] && ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS+=($arg_raw)
                           fi
                         }
                         ;;

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -243,6 +243,7 @@ _zsh_highlight_highlighter_main_paint()
     'command' ''
     'nice' n
     'sudo' Cgprtu
+    'doas' aCu
   )
 
   if [[ $zsyh_user_options[ignorebraces] == on || ${zsyh_user_options[ignoreclosebraces]:-off} == on ]]; then

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -289,8 +289,9 @@ _zsh_highlight_highlighter_main_paint()
   #
   # The states are:
   # - :start:      Command word
-  # - :sudo_opt:   A leading-dash option to sudo (such as "-u" or "-i")
-  # - :sudo_arg:   The argument to a sudo leading-dash option that takes one,
+  # - :sudo_opt:   A leading-dash option to a precommand, whether it takes an
+  #                argument or not.  (Example: sudo's "-u" or "-i".)
+  # - :sudo_arg:   The argument to a precommand's leading-dash option,
   #                when given as a separate word; i.e., "foo" in "-u foo" (two
   #                words) but not in "-ufoo" (one word).
   # - :regular:    "Not a command word", and command delimiters are permitted.

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -469,8 +469,14 @@ _zsh_highlight_highlighter_main_paint()
       # parameters that refer to commands, functions, and builtins.
       local -a match mbegin mend
       local MATCH; integer MBEGIN MEND
+      local parameter_name
+      if [[ $arg[1] == '$' ]] && [[ ${arg[2]} == '{' ]] && [[ ${arg[-1]} == '}' ]]; then
+        parameter_name=${${arg:2}%?}
+      elif [[ $arg[1] == '$' ]]; then
+        parameter_name=${arg:1}
+      fi
       if [[ $res == none ]] && (( ${+parameters} )) &&
-         [[ ${arg[1]} == \$ ]] && [[ ${arg:1} =~ ^([A-Za-z_][A-Za-z0-9_]*|[0-9]+)$ ]] &&
+         [[ ${parameter_name} =~ ^([A-Za-z_][A-Za-z0-9_]*|[0-9]+)$ ]] &&
          (( ${+parameters[${MATCH}]} ))
          then
         arg=${(P)MATCH}

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -505,17 +505,20 @@ _zsh_highlight_highlighter_main_paint()
     # Parse the sudo command line
     if (( ! in_redirection )); then
       if [[ $this_word == *':sudo_opt:'* ]]; then
-        case "$arg" in
+        if [[ -n $flags_with_argument ]] &&
+           [[ $arg == '-'[$flags_with_argument] ]]; then
           # Flag that requires an argument
-          '-'[$flags_with_argument])
-                       this_word=${this_word//:start:/};
-                       next_word=':sudo_arg:';;
+          this_word=${this_word//:start:/}
+          next_word=':sudo_arg:'
+        elif [[ $arg == '-'* ]]; then
+          # Flag that requires no argument, or unknown flag.
           # This prevents misbehavior with sudo -u -otherargument
-          '-'*)        this_word=${this_word//:start:/};
-                       next_word+=':start:';
-                       next_word+=':sudo_opt:';;
-          *)           ;;
-        esac
+          this_word=${this_word//:start:/}
+          next_word+=':start:'
+          next_word+=':sudo_opt:'
+        else
+          #
+        fi
       elif [[ $this_word == *':sudo_arg:'* ]]; then
         next_word+=':sudo_opt:'
         next_word+=':start:'

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -241,6 +241,7 @@ _zsh_highlight_highlighter_main_paint()
   local -A precommand_options
   precommand_options=(
     'command' ''
+    'nice' n
     'sudo' Cgprtu
   )
 

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -240,6 +240,7 @@ _zsh_highlight_highlighter_main_paint()
   # for that precommand.
   local -A precommand_options
   precommand_options=(
+    'command' ''
     'sudo' Cgprtu
   )
 
@@ -261,7 +262,7 @@ _zsh_highlight_highlighter_main_paint()
     # ';;' ';&' ';|'
   )
   ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS=(
-    'builtin' 'command' 'exec' 'nocorrect' 'noglob'
+    'builtin' 'exec' 'nocorrect' 'noglob'
     'pkexec' # immune to #121 because it's usually not passed --option flags
   )
 
@@ -532,14 +533,14 @@ _zsh_highlight_highlighter_main_paint()
      style=reserved-word # de facto a reserved word, although not de jure
      next_word=':start:'
    elif [[ $this_word == *':start:'* ]] && (( in_redirection == 0 )); then # $arg is the command word
-     if [[ -n ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$arg"} ]]; then
-      style=precommand
-     elif (( ${+precommand_options[$arg]} )) && { _zsh_highlight_main__type $arg; [[ -n $REPLY && $REPLY != "none" ]] }; then
+     if (( ${+precommand_options[$arg]} )) && { _zsh_highlight_main__type $arg; [[ -n $REPLY && $REPLY != "none" ]] }; then
       style=precommand
       flags_with_argument=${precommand_options[$arg]}
       next_word=${next_word//:regular:/}
       next_word+=':sudo_opt:'
       next_word+=':start:'
+     elif [[ -n ${(M)ZSH_HIGHLIGHT_TOKENS_PRECOMMANDS:#"$arg"} ]]; then
+      style=precommand
      else
       case $res in
         reserved)       # reserved word

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -459,6 +459,26 @@ _zsh_highlight_highlighter_main_paint()
       }
     fi
 
+    # Expand parameters.
+    #
+    # ### For now, expand just '$foo', like that, without braces or anything.
+    () {
+      # That's not entirely correct --- if the parameter's value happens to be a reserved
+      # word, the parameter expansion will be highlighted as a reserved word --- but that
+      # incorrectness is outweighed by the usability improvement of permitting the use of
+      # parameters that refer to commands, functions, and builtins.
+      local -a match mbegin mend
+      local MATCH; integer MBEGIN MEND
+      if [[ $res == none ]] && (( ${+parameters} )) &&
+         [[ ${arg[1]} == \$ ]] && [[ ${arg:1} =~ ^([A-Za-z_][A-Za-z0-9_]*|[0-9]+)$ ]] &&
+         (( ${+parameters[${MATCH}]} ))
+         then
+        arg=${(P)MATCH}
+        _zsh_highlight_main__type "$arg"
+        res=$REPLY
+      fi
+    }
+
     # Special-case the first word after 'sudo'.
     if (( ! in_redirection )); then
       if [[ $this_word == *':sudo_opt:'* ]] && [[ $arg != -* ]]; then
@@ -499,23 +519,6 @@ _zsh_highlight_highlighter_main_paint()
       next_word+=':sudo_opt:'
       next_word+=':start:'
      else
-      () {
-        # Special-case: command word is '$foo', like that, without braces or anything.
-        #
-        # That's not entirely correct --- if the parameter's value happens to be a reserved
-        # word, the parameter expansion will be highlighted as a reserved word --- but that
-        # incorrectness is outweighed by the usability improvement of permitting the use of
-        # parameters that refer to commands, functions, and builtins.
-        local -a match mbegin mend
-        local MATCH; integer MBEGIN MEND
-        if [[ $res == none ]] && (( ${+parameters} )) &&
-           [[ ${arg[1]} == \$ ]] && [[ ${arg:1} =~ ^([A-Za-z_][A-Za-z0-9_]*|[0-9]+)$ ]] &&
-           (( ${+parameters[${MATCH}]} ))
-           then
-          _zsh_highlight_main__type ${(P)MATCH}
-          res=$REPLY
-        fi
-      }
       case $res in
         reserved)       # reserved word
                         style=reserved-word

--- a/highlighters/main/test-data/alias-comment1.zsh
+++ b/highlighters/main/test-data/alias-comment1.zsh
@@ -27,14 +27,11 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
-alias a=:
-f() {}
-
-BUFFER='a;f;'
+# see alias-comment2.zsh
+setopt interactivecomments
+alias x=$'# foo\npwd'
+BUFFER='x'
 
 expected_region_highlight=(
-  "1 1 alias" # f
-  "2 2 commandseparator" # ;
-  "3 3 function" # g
-  "4 4 commandseparator" # ;
+  "1 1 alias 'interactivecomments applies to aliases'" # x becomes pwd
 )

--- a/highlighters/main/test-data/alias-comment2.zsh
+++ b/highlighters/main/test-data/alias-comment2.zsh
@@ -27,14 +27,11 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
-alias a=:
-f() {}
-
-BUFFER='a;f;'
+# see alias-comment1.zsh
+setopt NO_interactivecomments
+alias x=$'# foo\npwd'
+BUFFER='x'
 
 expected_region_highlight=(
-  "1 1 alias" # f
-  "2 2 commandseparator" # ;
-  "3 3 function" # g
-  "4 4 commandseparator" # ;
+  "1 1 unknown-token" # x becomes #
 )

--- a/highlighters/main/test-data/commmand-parameter.zsh
+++ b/highlighters/main/test-data/commmand-parameter.zsh
@@ -34,5 +34,5 @@ BUFFER='$x "argument"; $y'
 expected_region_highlight=(
   "1 2 command" # $x
   "4 13 double-quoted-argument" # "argument"
-  "16 17 precommand 'parameter expansion precedes precommand recognition'" # $y (sudo)
+  "16 17 precommand" # $y (sudo)
 )

--- a/highlighters/main/test-data/commmand-parameter.zsh
+++ b/highlighters/main/test-data/commmand-parameter.zsh
@@ -28,9 +28,11 @@
 # -------------------------------------------------------------------------------------------------
 
 local x=/usr/bin/env
-BUFFER='$x "argument"'
+local y=sudo
+BUFFER='$x "argument"; $y'
 
 expected_region_highlight=(
   "1 2 command" # $x
   "4 13 double-quoted-argument" # "argument"
+  "16 17 precommand 'parameter expansion precedes precommand recognition'" # $y (sudo)
 )

--- a/highlighters/main/test-data/path-dollared-word3.zsh
+++ b/highlighters/main/test-data/path-dollared-word3.zsh
@@ -35,5 +35,5 @@ BUFFER='$PWD; ${PWD}'
 
 expected_region_highlight=(
   "1 4 path" # $PWD
-  "7 12 unknown-token" # ${PWD}
+  "7 12 path" # ${PWD}
 )

--- a/highlighters/main/test-data/path-dollared-word3.zsh
+++ b/highlighters/main/test-data/path-dollared-word3.zsh
@@ -29,9 +29,11 @@
 
 # «/usr» at this point would be highlighted as path_prefix; so should
 # a parameter that expands to an equivalent string be highlighted.
+#
+# More complicated parameter substitutions aren't eval'd; issue #328.
 BUFFER='$PWD; ${PWD}'
 
 expected_region_highlight=(
-  "1 4 unknown-token" # $PWD - not eval'd; issue #328
+  "1 4 path" # $PWD
   "7 12 unknown-token" # ${PWD}
 )

--- a/highlighters/main/test-data/precommand2.zsh
+++ b/highlighters/main/test-data/precommand2.zsh
@@ -31,6 +31,6 @@ BUFFER='command -v ls'
 
 expected_region_highlight=(
   "1 7 precommand" # command
-  "9 10 single-hyphen-option 'issue #343'" # -v
-  "12 13 command 'issue #343'" # ls
+  "9 10 single-hyphen-option" # -v
+  "12 13 command" # ls
 )

--- a/highlighters/main/test-data/precommand3.zsh
+++ b/highlighters/main/test-data/precommand3.zsh
@@ -1,0 +1,41 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2016 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+BUFFER='nice -n10 ls; nice -n 10 ls'
+
+expected_region_highlight=(
+  "1 4 precommand" # nice
+  "6 9 single-hyphen-option" # -n10
+  "11 12 command" # ls
+  "13 13 commandseparator" # ;
+  "15 18 precommand" # nice
+  "20 21 single-hyphen-option" # -n
+  "23 24 default" # 10
+  "26 27 command" # ls
+)


### PR DESCRIPTION
This is i343-precommands-v2, but rebased, and with an extra commit about ${foo} parameter expansions.

Related to #264, #328, #343, #168, #365 (see log messages and added comments).