### PR TITLE
main: Only highlight characters special to globbing as globbing

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -799,9 +799,8 @@ _zsh_highlight_main_highlighter_check_path()
 # This command will at least highlight start_pos to end_pos with the default style
 _zsh_highlight_main_highlighter_highlight_argument()
 {
-  local base_style=default i path_eligible style
+  local base_style=default i path_eligible=1 style
   local -a highlights reply
-  path_eligible=1
 
   local -a match mbegin mend
   local MATCH; integer MBEGIN MEND
@@ -841,10 +840,9 @@ _zsh_highlight_main_highlighter_highlight_argument()
         fi;;
       *)
         if $highlight_glob && [[ ${arg[$i]} =~ ^[*?] || ${arg:$i-1} =~ ^\<[0-9]*-[0-9]*\> ]]; then
-	  (( i += $#MATCH - 1 ))
-          base_style=globbing
+          highlights+=($(( start_pos + i - 1 )) $(( start_pos + i + $#MATCH - 1)) globbing)
+          (( i += $#MATCH - 1 ))
           path_eligible=0
-          break
         else
           continue
         fi

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -840,7 +840,7 @@ _zsh_highlight_main_highlighter_highlight_argument()
           (( i += 1 ))
         fi;;
       *)
-        if $highlight_glob && [[ ${arg[$i]} == [*?] || ${arg:$i-1} == \<[0-9]#-[0-9]#\>* ]]; then
+        if $highlight_glob && [[ ${arg[$i]} =~ ^[*?] || ${arg:$i-1} =~ ^\<[0-9]*-[0-9]*\> ]]; then
 	  (( i += $#MATCH - 1 ))
           base_style=globbing
           path_eligible=0

--- a/highlighters/main/test-data/globs-with-quoting.zsh
+++ b/highlighters/main/test-data/globs-with-quoting.zsh
@@ -1,5 +1,6 @@
+#!/usr/bin/env zsh
 # -------------------------------------------------------------------------------------------------
-# Copyright (c) 2015 zsh-syntax-highlighting contributors
+# Copyright (c) 2018 zsh-syntax-highlighting contributors
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted
@@ -27,15 +28,15 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
-BUFFER=': foo* bar? *baz qux\?'
+BUFFER=$': "foo"*\'bar\'?"baz?"<17-29>"qu*ux"'
 
 expected_region_highlight=(
-  "1 1 builtin" # :
-  "3 5 default" # foo
-  "6 6 globbing" # *
-  "8 10 default" # bar
-  "11 11 globbing" # ?
-  "13 13 globbing" # *
-  "14 16 default" # baz
-  "18 22 default" # qux\?
+  '1 1 builtin' # :
+  '3 7 double-quoted-argument' # "foo"
+  '8 8 globbing' # *
+  '9 13 single-quoted-argument' # 'bar'
+  '14 14 globbing' # ?
+  '15 20 double-quoted-argument' # "baz?"
+  '21 27 globbing' # <17-29>
+  '28 34 double-quoted-argument' # "qu*ux"
 )

--- a/highlighters/main/test-data/number_range-glob.zsh
+++ b/highlighters/main/test-data/number_range-glob.zsh
@@ -33,7 +33,9 @@ BUFFER='print <-> x<->y <foo2-3>'
 expected_region_highlight=(
   '1 5 builtin' # print
   '7 9 globbing' # <->
-  '11 15 globbing' # x<->
+  '11 11 default' # x
+  '12 14 globbing' # <->
+  '15 15 default' # y
   '17 17 redirection' # <
   '18 23 default' # foo2-3 (the filename)
   '24 24 redirection' # >


### PR DESCRIPTION
Instead of highlighting the full word as globbing, only highlight the `*`, `?`, or `<->`. I think this improves legibility and lets users still see quoting highlighting.