### PR TITLE
main: Only highlight one base_style in _highlight_arguments

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -750,8 +750,8 @@ _zsh_highlight_main_highlighter_check_assign()
 _zsh_highlight_main_highlighter_highlight_path_separators()
 {
   local pos style_pathsep
-  style_pathsep=${style}_pathseparator
-  [[ -z "$ZSH_HIGHLIGHT_STYLES[$style_pathsep]" || "$ZSH_HIGHLIGHT_STYLES[$style]" == "$ZSH_HIGHLIGHT_STYLES[$style_pathsep]" ]] && return 0
+  style_pathsep=$1_pathseparator
+  [[ -z "$ZSH_HIGHLIGHT_STYLES[$style_pathsep]" || "$ZSH_HIGHLIGHT_STYLES[$1]" == "$ZSH_HIGHLIGHT_STYLES[$style_pathsep]" ]] && return 0
   for (( pos = start_pos; $pos <= end_pos; pos++ )) ; do
     if [[ $BUFFER[pos] == / ]]; then
       _zsh_highlight_main_add_region_highlight $((pos - 1)) $pos $style_pathsep
@@ -841,7 +841,7 @@ _zsh_highlight_main_highlighter_highlight_argument()
   if (( path_eligible )) && _zsh_highlight_main_highlighter_check_path; then
     style=$REPLY
     _zsh_highlight_main_add_region_highlight $start_pos $end_pos $style
-    _zsh_highlight_main_highlighter_highlight_path_separators
+    _zsh_highlight_main_highlighter_highlight_path_separators $style
   fi
 }
 

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -799,14 +799,13 @@ _zsh_highlight_main_highlighter_check_path()
 # This command will at least highlight start_pos to end_pos with the default style
 _zsh_highlight_main_highlighter_highlight_argument()
 {
-  local i path_eligible style
+  local base_style=default i path_eligible style
   local -a highlights reply
   path_eligible=1
 
   local -a match mbegin mend
   local MATCH; integer MBEGIN MEND
 
-  _zsh_highlight_main_add_region_highlight $start_pos $end_pos default
   for (( i = 1 ; i <= end_pos - start_pos ; i += 1 )); do
     case "$arg[$i]" in
       "\\") (( i += 1 )); continue;;
@@ -843,7 +842,7 @@ _zsh_highlight_main_highlighter_highlight_argument()
       *)
         if $highlight_glob && [[ ${arg[$i]} == [*?] || ${arg:$i-1} == \<[0-9]#-[0-9]#\>* ]]; then
 	  (( i += $#MATCH - 1 ))
-          _zsh_highlight_main_add_region_highlight $start_pos $end_pos globbing
+          base_style=globbing
           path_eligible=0
           break
         else
@@ -854,11 +853,12 @@ _zsh_highlight_main_highlighter_highlight_argument()
   done
 
   if (( path_eligible )) && _zsh_highlight_main_highlighter_check_path; then
-    style=$REPLY
-    _zsh_highlight_main_add_region_highlight $start_pos $end_pos $style
+    base_style=$REPLY
+    _zsh_highlight_main_highlighter_highlight_path_separators $base_style
     highlights+=($reply)
   fi
 
+  highlights=($start_pos $end_pos $base_style $highlights)
   _zsh_highlight_main_add_many_region_highlights $highlights
 }
 


### PR DESCRIPTION
Closes #481 

If this is ok, I think the check for `{single,double}-hyphen-option` should move into `_highlight_arguments` as a `base_style` as well.