### PR TITLE
Don't match redirection operators in command substitutions as <-> number range globs.

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -822,7 +822,7 @@ _zsh_highlight_main_highlighter_highlight_argument()
         elif [[ $arg[i+1] == [*@#?-$!] ]]; then
           (( i += 1 ))
         fi;;
-      [*?]*|\<*)
+      [*?]*|\<[0-9]#-[0-9]#\>)
 	# The '<' is for the <-> globbing syntax.  (This function doesn't get called on redirection tokens.)
         if $highlight_glob; then
           _zsh_highlight_main_add_region_highlight $start_pos $end_pos globbing

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -803,12 +803,12 @@ _zsh_highlight_main_highlighter_highlight_argument()
 
   _zsh_highlight_main_add_region_highlight $start_pos $end_pos default
   for (( i = 1 ; i <= end_pos - start_pos ; i += 1 )); do
-    case "$arg[$i]" in
-      "\\") (( i += 1 )); continue;;
-      "'") _zsh_highlight_main_highlighter_highlight_single_quote $i; (( i = REPLY ));;
-      '"') _zsh_highlight_main_highlighter_highlight_double_quote $i; (( i = REPLY ));;
-      '`') _zsh_highlight_main_highlighter_highlight_backtick $i; (( i = REPLY ));;
-      '$')
+    case ${arg:$i-1} in
+      "\\"*) (( i += 1 )); continue;;
+      "'"*) _zsh_highlight_main_highlighter_highlight_single_quote $i; (( i = REPLY ));;
+      '"'*) _zsh_highlight_main_highlighter_highlight_double_quote $i; (( i = REPLY ));;
+      '`'*) _zsh_highlight_main_highlighter_highlight_backtick $i; (( i = REPLY ));;
+      '$'*)
         if [[ $arg[i+1] == "'" ]]; then
           _zsh_highlight_main_highlighter_highlight_dollar_quote $i
           (( i = REPLY ))
@@ -822,7 +822,7 @@ _zsh_highlight_main_highlighter_highlight_argument()
         elif [[ $arg[i+1] == [*@#?-$!] ]]; then
           (( i += 1 ))
         fi;;
-      [*?]|\<)
+      [*?]*|\<*)
 	# The '<' is for the <-> globbing syntax.  (This function doesn't get called on redirection tokens.)
         if $highlight_glob; then
           _zsh_highlight_main_add_region_highlight $start_pos $end_pos globbing

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -822,7 +822,7 @@ _zsh_highlight_main_highlighter_highlight_argument()
         elif [[ $arg[i+1] == [*@#?-$!] ]]; then
           (( i += 1 ))
         fi;;
-      [*?]*|\<[0-9]#-[0-9]#\>)
+      [*?]*|\<[0-9]#-[0-9]#\>*)
 	# The '<' is for the <-> globbing syntax.  (This function doesn't get called on redirection tokens.)
         if $highlight_glob; then
           _zsh_highlight_main_add_region_highlight $start_pos $end_pos globbing

--- a/highlighters/main/test-data/number_range-glob.zsh
+++ b/highlighters/main/test-data/number_range-glob.zsh
@@ -28,13 +28,13 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
-BUFFER='print <-> x<-> <foo2-3>'
+BUFFER='print <-> x<->y <foo2-3>'
 
 expected_region_highlight=(
   '1 5 builtin' # print
   '7 9 globbing' # <->
-  '11 14 globbing' # x<->
-  '16 16 redirection' # <
-  '17 22 default' # foo2-3 (the filename)
-  '23 23 redirection' # >
+  '11 15 globbing' # x<->
+  '17 17 redirection' # <
+  '18 23 default' # foo2-3 (the filename)
+  '24 24 redirection' # >
 )

--- a/highlighters/main/test-data/redirection-in-cmdsubst.zsh
+++ b/highlighters/main/test-data/redirection-in-cmdsubst.zsh
@@ -32,5 +32,5 @@ BUFFER=$': $(<foo)'
 
 expected_region_highlight=(
   '1 1 builtin' # :
-  '3 9 default "issue #483"' # $(<foo)
+  '3 9 default' # $(<foo)
 )


### PR DESCRIPTION
Fixes #483.