### PR TITLE
'main': Highlight hyphen options as files when so-named files are present

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -801,7 +801,7 @@ _zsh_highlight_main_highlighter_highlight_argument()
     else
       base_style=single-hyphen-option
     fi
-    path_eligible=0
+    #path_eligible=0
   fi
 
   for (( i = 1 ; i <= end_pos - start_pos ; i += 1 )); do


### PR DESCRIPTION
E.g., «echo -foo» when «./-foo» exists.