### PR TITLE
tests: Directly diff expected_region_highlight against region_highlight

### DIFF
--- a/highlighters/brackets/test-data/cursor-matchingbracket-line-finish.zsh
+++ b/highlighters/brackets/test-data/cursor-matchingbracket-line-finish.zsh
@@ -33,5 +33,4 @@ BUFFER=': $foo[bar]'
 CURSOR=6 # cursor is zero-based
 
 expected_region_highlight=(
-  "11 11 NONE"
 )

--- a/highlighters/brackets/test-data/cursor-matchingbracket.zsh
+++ b/highlighters/brackets/test-data/cursor-matchingbracket.zsh
@@ -27,6 +27,8 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
+unsorted=1
+
 ZSH_HIGHLIGHT_STYLES[bracket-level-1]=
 ZSH_HIGHLIGHT_STYLES[bracket-level-2]=
 ZSH_HIGHLIGHT_STYLES[bracket-level-3]=
@@ -35,5 +37,11 @@ BUFFER=': ((( )))'
 CURSOR=2 # cursor is zero-based
 
 expected_region_highlight=(
+  "3 3 bracket-level-1"
+  "4 4 bracket-level-2"
+  "5 5 bracket-level-3"
+  "7 7 bracket-level-3"
+  "8 8 bracket-level-2"
+  "9 9 bracket-level-1"
   "9 9 cursor-matchingbracket"
 )

--- a/highlighters/brackets/test-data/empty-styles.zsh
+++ b/highlighters/brackets/test-data/empty-styles.zsh
@@ -30,5 +30,4 @@
 BUFFER=': (x)'
 
 expected_region_highlight=(
-  "1 5 NONE"
 )

--- a/highlighters/brackets/test-data/loop-styles.zsh
+++ b/highlighters/brackets/test-data/loop-styles.zsh
@@ -27,6 +27,8 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
+unsorted=1
+
 ZSH_HIGHLIGHT_STYLES[bracket-level-1]=
 ZSH_HIGHLIGHT_STYLES[bracket-level-2]=
 ZSH_HIGHLIGHT_STYLES[bracket-level-3]=

--- a/highlighters/brackets/test-data/mismatch-patentheses.zsh
+++ b/highlighters/brackets/test-data/mismatch-patentheses.zsh
@@ -27,6 +27,8 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
+unsorted=1
+
 ZSH_HIGHLIGHT_STYLES[bracket-level-1]=
 ZSH_HIGHLIGHT_STYLES[bracket-level-2]=
 

--- a/highlighters/brackets/test-data/near-quotes.zsh
+++ b/highlighters/brackets/test-data/near-quotes.zsh
@@ -27,6 +27,8 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
+unsorted=1
+
 ZSH_HIGHLIGHT_STYLES[bracket-level-1]=
 ZSH_HIGHLIGHT_STYLES[bracket-level-2]=
 
@@ -34,10 +36,7 @@ BUFFER=': {"{x}"}'
 
 expected_region_highlight=(
   "3 3 bracket-level-1"
-  "4 4 NONE"
   "5 5 bracket-level-2"
-  "6 6 NONE"
   "7 7 bracket-level-2"
-  "8 8 NONE"
   "9 9 bracket-level-1"
 )

--- a/highlighters/brackets/test-data/nested-parentheses.zsh
+++ b/highlighters/brackets/test-data/nested-parentheses.zsh
@@ -27,6 +27,8 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
+unsorted=1
+
 ZSH_HIGHLIGHT_STYLES[bracket-level-1]=
 ZSH_HIGHLIGHT_STYLES[bracket-level-2]=
 ZSH_HIGHLIGHT_STYLES[bracket-level-3]=

--- a/highlighters/brackets/test-data/only-error.zsh
+++ b/highlighters/brackets/test-data/only-error.zsh
@@ -30,6 +30,5 @@
 BUFFER=': x)'
 
 expected_region_highlight=(
-  "1 3 NONE"
   "4 4 bracket-error" # )
 )

--- a/highlighters/brackets/test-data/quoted-patentheses.zsh
+++ b/highlighters/brackets/test-data/quoted-patentheses.zsh
@@ -30,7 +30,5 @@
 BUFFER='echo "foo ( bar"'
 
 expected_region_highlight=(
-"1 10 NONE"
 "11 11 bracket-error"
-"12 16 NONE"
 )

--- a/highlighters/brackets/test-data/simple-parentheses.zsh
+++ b/highlighters/brackets/test-data/simple-parentheses.zsh
@@ -27,6 +27,8 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
+unsorted=1
+
 ZSH_HIGHLIGHT_STYLES[bracket-level-1]=
 ZSH_HIGHLIGHT_STYLES[bracket-level-2]=
 

--- a/highlighters/brackets/test-data/unclosed-patentheses.zsh
+++ b/highlighters/brackets/test-data/unclosed-patentheses.zsh
@@ -27,6 +27,8 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
+unsorted=1
+
 ZSH_HIGHLIGHT_STYLES[bracket-level-1]=
 ZSH_HIGHLIGHT_STYLES[bracket-level-2]=
 

--- a/highlighters/brackets/test-data/unclosed-patentheses2.zsh
+++ b/highlighters/brackets/test-data/unclosed-patentheses2.zsh
@@ -27,6 +27,8 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
+unsorted=1
+
 ZSH_HIGHLIGHT_STYLES[bracket-level-1]=
 
 BUFFER='echo {x})'

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -888,6 +888,8 @@ _zsh_highlight_main_highlighter_highlight_single_quote()
   if [[ $arg[i] == "'" ]]; then
     style=single-quoted-argument
   else
+    # If unclosed, i points past the end
+    (( i-- ))
     style=single-quoted-argument-unclosed
   fi
   reply=($(( start_pos + arg1 - 1 )) $(( start_pos + i )) $style $reply)
@@ -902,7 +904,7 @@ _zsh_highlight_main_highlighter_highlight_double_quote()
   local i j k style
   reply=()
 
-  for (( i = $1 + 1 ; i < end_pos - start_pos ; i += 1 )) ; do
+  for (( i = $1 + 1 ; i <= end_pos - start_pos ; i += 1 )) ; do
     (( j = i + start_pos - 1 ))
     (( k = j + 1 ))
     case "$arg[$i]" in
@@ -959,6 +961,8 @@ _zsh_highlight_main_highlighter_highlight_double_quote()
   if [[ $arg[i] == '"' ]]; then
     style=double-quoted-argument
   else
+    # If unclosed, i points past the end
+    (( i-- ))
     style=double-quoted-argument-unclosed
   fi
   reply=($(( start_pos + $1 - 1)) $(( start_pos + i )) $style $reply)
@@ -975,7 +979,7 @@ _zsh_highlight_main_highlighter_highlight_dollar_quote()
   integer c
   reply=()
 
-  for (( i = $1 + 2 ; i < end_pos - start_pos ; i += 1 )) ; do
+  for (( i = $1 + 2 ; i <= end_pos - start_pos ; i += 1 )) ; do
     (( j = i + start_pos - 1 ))
     (( k = j + 1 ))
     case "$arg[$i]" in
@@ -1011,6 +1015,8 @@ _zsh_highlight_main_highlighter_highlight_dollar_quote()
   if [[ $arg[i] == "'" ]]; then
     style=dollar-quoted-argument
   else
+    # If unclosed, i points past the end
+    (( i-- ))
     style=dollar-quoted-argument-unclosed
   fi
   reply=($(( start_pos + $1 - 1 )) $(( start_pos + i )) $style $reply)
@@ -1027,6 +1033,8 @@ _zsh_highlight_main_highlighter_highlight_backtick()
   if [[ $arg[i] == '`' ]]; then
     style=back-quoted-argument
   else
+    # If unclosed, i points past the end
+    (( i-- ))
     style=back-quoted-argument-unclosed
   fi
   reply=($(( start_pos + arg1 - 1 )) $(( start_pos + i )) $style)

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -104,7 +104,8 @@ _zsh_highlight_main_add_region_highlight() {
   (( start -= $#PREBUFFER ))
   (( end -= $#PREBUFFER ))
 
-  (( end < 0 )) && return # having end<0 would be a bug
+  (( start >= end )) && { print -r -- >&2 "zsh-syntax-highlighting: BUG: _zsh_highlight_main_add_region_highlight: start($start) >= end($end)"; return }
+  (( end <= 0 )) && return
   (( start < 0 )) && start=0 # having start<0 is normal with e.g. multiline strings
   _zsh_highlight_add_highlight $start $end "$@"
 }

--- a/highlighters/main/test-data/alias-assignment1.zsh
+++ b/highlighters/main/test-data/alias-assignment1.zsh
@@ -34,4 +34,5 @@ BUFFER='x=y ls'
 
 expected_region_highlight=(
   "1 3 unknown-token" # x=y
+  "5 6 default" # ls
 )

--- a/highlighters/main/test-data/alias.zsh
+++ b/highlighters/main/test-data/alias.zsh
@@ -49,5 +49,6 @@ if zmodload -e zsh/parameter || [[ "$(type -w x.alias2)" == *suffix* ]]; then
   )
 fi
 expected_region_highlight+=(
+  "9 9 commandseparator" # ;
   "11 16 alias" # alias1
 )

--- a/highlighters/main/test-data/alias.zsh
+++ b/highlighters/main/test-data/alias.zsh
@@ -43,7 +43,7 @@ BUFFER='x.alias2; alias1'
 # functionality is present, and skip verifying suffix-alias highlighting
 # if it isn't.
 expected_region_highlight=()
-if [[ "$(type -w x.alias2)" == *suffix* ]]; then
+if zmodload -e zsh/parameter || [[ "$(type -w x.alias2)" == *suffix* ]]; then
   expected_region_highlight+=(
     "1 8 suffix-alias" # x.alias2
   )

--- a/highlighters/main/test-data/anonymous-function.zsh
+++ b/highlighters/main/test-data/anonymous-function.zsh
@@ -37,5 +37,8 @@ expected_region_highlight=(
   "16 17 reserved-word" # ()
   "19 19 reserved-word" # {
   "21 24 builtin" # echo
+  "26 30 default" # world
+  "32 32 reserved-word" # }
+  "34 43 default" # "argument"
   "34 43 double-quoted-argument" # "argument"
 )

--- a/highlighters/main/test-data/assign-append.zsh
+++ b/highlighters/main/test-data/assign-append.zsh
@@ -31,4 +31,7 @@ BUFFER='a+=(lorem ipsum)'
 
 expected_region_highlight=(
   "1 4 assign" # a+=(
+  "5 9 default" # lorem
+  "11 15 default" # ipsum
+  "16 16 assign" # )
 )

--- a/highlighters/main/test-data/assign-array.zsh
+++ b/highlighters/main/test-data/assign-array.zsh
@@ -32,6 +32,8 @@ BUFFER='(A=(hello world))'
 expected_region_highlight=(
   "1 1 reserved-word" # (
   "2 4 assign" # A=(
+  "5 9 default" # hello
+  "11 15 default" # world
   "16 16 assign" # )
   "17 17 reserved-word" # )
 )

--- a/highlighters/main/test-data/assign-array2.zsh
+++ b/highlighters/main/test-data/assign-array2.zsh
@@ -31,6 +31,8 @@ BUFFER='A=(hello world) ls'
 
 expected_region_highlight=(
   "1 3 assign" # A=(
+  "4 8 default" # hello
+  "10 14 default" # world
   "15 15 assign" # )
   "17 18 command" # ls
 )

--- a/highlighters/main/test-data/assign-array3.zsh
+++ b/highlighters/main/test-data/assign-array3.zsh
@@ -31,6 +31,8 @@ BUFFER='A=(hello world) b=42'
 
 expected_region_highlight=(
   "1 3 assign" # A=(
+  "4 8 default" # hello
+  "10 14 default" # world
   "15 15 assign" # )
   "17 20 assign" # b=42
 )

--- a/highlighters/main/test-data/assign-semicolon.zsh
+++ b/highlighters/main/test-data/assign-semicolon.zsh
@@ -30,6 +30,9 @@
 BUFFER='A=1; echo hello world'
 
 expected_region_highlight=(
+  "1 3 assign" # A=1
   "4 4 commandseparator" # ;
   "6 9 builtin" # echo
+  "11 15 default" # hello
+  "17 21 default" # world
 )

--- a/highlighters/main/test-data/assign.zsh
+++ b/highlighters/main/test-data/assign.zsh
@@ -32,6 +32,7 @@ BUFFER='A=1 b=("foo" bar)'
 expected_region_highlight=(
   "1 3 assign" # A=1
   "5 7 assign" # b=(
+  "8 12 default" # "foo"
   "8 12 double-quoted-argument" # "foo"
   "14 16 default" # bar
   "17 17 assign" # )

--- a/highlighters/main/test-data/back-quoted-argument.zsh
+++ b/highlighters/main/test-data/back-quoted-argument.zsh
@@ -31,9 +31,12 @@
 BUFFER='echo `echo \`42\`` "is `echo equal` to" `echo 6 times 9'
 
 expected_region_highlight=(
+  "1 4 builtin" # echo
+  "6 18 default" # `echo \`42\``
   "6 18 back-quoted-argument" # `echo \`42\``
-  "20 23 double-quoted-argument" # "is
+  "20 39 default" # "is `echo equal` to"
+  "20 39 double-quoted-argument" # "is `echo equal` to"
   "24 35 back-quoted-argument" # `echo equal`
-  "36 39 double-quoted-argument" # to"
+  "41 55 default" # `echo 6 times 9
   "41 55 back-quoted-argument-unclosed" # `echo 6 times 9
 )

--- a/highlighters/main/test-data/brackets-mismatch7.zsh
+++ b/highlighters/main/test-data/brackets-mismatch7.zsh
@@ -34,6 +34,7 @@ expected_region_highlight=(
   '1 3 reserved-word' # for
   '5 5 default' # n
   '7 8 default' # in
+  '10 10 default' # *
   '10 10 globbing' # *
   '11 11 commandseparator' # ;
   '13 14 reserved-word' # do

--- a/highlighters/main/test-data/commandseparator.zsh
+++ b/highlighters/main/test-data/commandseparator.zsh
@@ -30,6 +30,7 @@
 BUFFER=':; pwd &! ls'
 
 expected_region_highlight=(
+  "1 1 builtin" # :
   "2 2 commandseparator" # ;
   "4 6 builtin" # pwd
   "8 9 commandseparator" # &!

--- a/highlighters/main/test-data/comment-leading.zsh
+++ b/highlighters/main/test-data/comment-leading.zsh
@@ -32,6 +32,5 @@ setopt interactive_comments
 BUFFER='# echo foo'
 
 expected_region_highlight=(
-  "1 1 comment" # #
-  "2 10 comment" # " echo foo"
+  "1 10 comment" # # echo foo
 )

--- a/highlighters/main/test-data/comments.zsh
+++ b/highlighters/main/test-data/comments.zsh
@@ -33,6 +33,7 @@ BUFFER='echo "foo #bar" #baz # quux'
 
 expected_region_highlight=(
   "1 4 builtin" # echo
+  "6 15 default" # "foo #bar"
   "6 15 double-quoted-argument" # "foo #bar"
   "17 27 comment" # #baz # quux
 )

--- a/highlighters/main/test-data/commmand-parameter.zsh
+++ b/highlighters/main/test-data/commmand-parameter.zsh
@@ -32,5 +32,6 @@ BUFFER='$x "argument"'
 
 expected_region_highlight=(
   "1 2 command" # $x
+  "4 13 default" # "argument"
   "4 13 double-quoted-argument" # "argument"
 )

--- a/highlighters/main/test-data/control-flow.zsh
+++ b/highlighters/main/test-data/control-flow.zsh
@@ -34,17 +34,24 @@ expected_region_highlight+=(
   "7 8 reserved-word" # if
   "10 13 builtin" # echo
   "15 19 default" # Hello
+  "20 20 commandseparator" # ;
   "22 25 reserved-word" # then
   "27 28 command" # ls
   "30 30 path" # /
   "31 31 commandseparator" # ;
   "33 36 reserved-word" # else
   "38 39 command" # ls
+  "40 40 commandseparator" # ;
   "42 43 reserved-word" # fi
+  "44 44 commandseparator" # ;
   "46 47 reserved-word" # do
   "49 52 command" # stat
+  "54 56 default" # "x"
   "54 56 double-quoted-argument" # "x"
+  "57 57 commandseparator" # ;
   "59 62 reserved-word" # done
+  "63 63 commandseparator" # ;
   "65 70 reserved-word" # repeat
+  "72 73 default" # 10
   "75 76 command" # ls
 )

--- a/highlighters/main/test-data/dollar-dollar.zsh
+++ b/highlighters/main/test-data/dollar-dollar.zsh
@@ -32,8 +32,8 @@ BUFFER=': "$$ $$foo"'
 
 expected_region_highlight=(
   '1 1 builtin' # :
-  '3 3 double-quoted-argument' # "
+  '3 12 default' # "$$ $$foo"
+  '3 12 double-quoted-argument' # "$$ $$foo"
   '4 5 dollar-double-quoted-argument' # $$
   '7 8 dollar-double-quoted-argument' # $$
-  '9 12 double-quoted-argument' # foo"
 )

--- a/highlighters/main/test-data/dollar-noise.zsh
+++ b/highlighters/main/test-data/dollar-noise.zsh
@@ -32,15 +32,11 @@ BUFFER=': "$- $# $* $@ $?"'
 
 expected_region_highlight=(
   '1 1 builtin' # :
-  '3 3 double-quoted-argument' # "
+  '3 18 default' # "$- $# $* $@ $?"
+  '3 18 double-quoted-argument' # "$- $# $* $@ $?"
   '4 5 dollar-double-quoted-argument' # $-
-  '6 6 double-quoted-argument' # <space>
   '7 8 dollar-double-quoted-argument' # $#
-  '9 9 double-quoted-argument' # <space>
   '10 11 dollar-double-quoted-argument' # $*
-  '12 12 double-quoted-argument' # <space>
   '13 14 dollar-double-quoted-argument' # $@
-  '15 15 double-quoted-argument' # <space>
   '16 17 dollar-double-quoted-argument' # $?
-  '18 18 double-quoted-argument' # "
 )

--- a/highlighters/main/test-data/dollar-paren.zsh
+++ b/highlighters/main/test-data/dollar-paren.zsh
@@ -32,7 +32,7 @@ BUFFER=': "$(:)"'
 
 expected_region_highlight=(
   '1 1 builtin' # :
-  '3 3 double-quoted-argument' # "
+  '3 8 default' # "$(:)"
+  '3 8 double-quoted-argument' # "$(:)"
   '4 4 dollar-double-quoted-argument' # $
-  '5 8 double-quoted-argument' # (:)"
 )

--- a/highlighters/main/test-data/dollar-quoted.zsh
+++ b/highlighters/main/test-data/dollar-quoted.zsh
@@ -30,6 +30,9 @@
 BUFFER=": \$'*' 'foo'"
 
 expected_region_highlight=(
+  "1 1 builtin" # :
+  "3 6 default" # $'*'
   "3 6 dollar-quoted-argument" # $'*' - not a glob
+  "8 12 default" # 'foo'
   "8 12 single-quoted-argument" # 'foo'
 )

--- a/highlighters/main/test-data/dollar-quoted2.zsh
+++ b/highlighters/main/test-data/dollar-quoted2.zsh
@@ -30,11 +30,10 @@
 BUFFER=": \$'foo\xbar\udeadbeef\uzzzz'"
 
 expected_region_highlight=(
-  "3 7 dollar-quoted-argument" # $'foo
+  "1 1 builtin" # :
+  "3 29 default" # $'foo\xbar\udeadbeef\uzzzz'
+  "3 29 dollar-quoted-argument" # $'foo\xbar\udeadbeef\uzzzz'
   "8 11 back-dollar-quoted-argument" # \xba
-  "12 12 dollar-quoted-argument" # r
   "13 18 back-dollar-quoted-argument" # \dead
-  "19 22 dollar-quoted-argument" # beef
   "23 24 unknown-token" # \u
-  "25 29 dollar-quoted-argument" # zzzz'
 )

--- a/highlighters/main/test-data/dollar-quoted3.zsh
+++ b/highlighters/main/test-data/dollar-quoted3.zsh
@@ -32,6 +32,8 @@
 BUFFER=": \$'\xa1"
 
 expected_region_highlight=(
-  "3 4 dollar-quoted-argument-unclosed" # $'
+  "1 1 builtin" # :
+  "3 8 default" # $'\xa1
+  "3 8 dollar-quoted-argument-unclosed" # $'\xa1
   "5 8 back-dollar-quoted-argument" # \xa1
 )

--- a/highlighters/main/test-data/double-hyphen-option.zsh
+++ b/highlighters/main/test-data/double-hyphen-option.zsh
@@ -30,5 +30,6 @@
 BUFFER='hello --world'
 
 expected_region_highlight=(
+  "1 5 unknown-token" # hello
   "7 13 double-hyphen-option" # --world
 )

--- a/highlighters/main/test-data/double-quoted.zsh
+++ b/highlighters/main/test-data/double-quoted.zsh
@@ -31,15 +31,12 @@ BUFFER=': "foo$bar:\`:\":\$:'
 BUFFER+=\\\\:\"
 
 expected_region_highlight=(
-  "3 6 double-quoted-argument" # "foo
+  "1 1 builtin" # :
+  "3 24 default" # "foo$bar:\`:\":\$:\\:"
+  "3 24 double-quoted-argument" # "foo$bar:\`:\":\$:\\:"
   "7 10 dollar-double-quoted-argument" # $bar
-  "11 11 double-quoted-argument" # :
   "12 13 back-double-quoted-argument" # \`
-  "14 14 double-quoted-argument" # :
   "15 16 back-double-quoted-argument" # \$
-  "17 17 double-quoted-argument" # :
   "18 19 back-double-quoted-argument" # \"
-  "20 20 double-quoted-argument" # :
   "21 22 back-double-quoted-argument" # \\
-  "23 24 double-quoted-argument" # :"
 )

--- a/highlighters/main/test-data/double-quoted2.zsh
+++ b/highlighters/main/test-data/double-quoted2.zsh
@@ -32,6 +32,8 @@
 BUFFER=': "foo$bar'
 
 expected_region_highlight=(
-  "3 6 double-quoted-argument-unclosed" # "foo
+  "1 1 builtin" # :
+  "3 10 default" # "foo$bar
+  "3 10 double-quoted-argument-unclosed" # "foo$bar
   "7 10 dollar-double-quoted-argument" # $bar
 )

--- a/highlighters/main/test-data/double-quoted3.zsh
+++ b/highlighters/main/test-data/double-quoted3.zsh
@@ -31,9 +31,12 @@ BUFFER=': "$" "$42foo"'
 BUFFER+=\ \"\\\'\\x\"
 
 expected_region_highlight=(
+  "1 1 builtin" # :
+  "3 5 default" # "$"
   "3 5 double-quoted-argument" # "$"
-  "7 7 double-quoted-argument" # "
+  "7 14 default" # "$42foo"
+  "7 14 double-quoted-argument" # "$42foo"
   "8 10 dollar-double-quoted-argument" # $42
-  "11 14 double-quoted-argument" # foo"
+  "16 21 default" # "\'\x"
   "16 21 double-quoted-argument" # "\'\x" - \' and \x are not escape sequences
 )

--- a/highlighters/main/test-data/double-quoted4.zsh
+++ b/highlighters/main/test-data/double-quoted4.zsh
@@ -30,7 +30,8 @@
 BUFFER=': "${foo}bar"'
 
 expected_region_highlight=(
-  "3 3 double-quoted-argument" # "
+  "1 1 builtin" # :
+  "3 13 default" # "${foo}bar"
+  "3 13 double-quoted-argument" # "${foo}bar"
   "4 9 dollar-double-quoted-argument" # ${foo}
-  "10 13 double-quoted-argument" # bar"
 )

--- a/highlighters/main/test-data/empty-command.zsh
+++ b/highlighters/main/test-data/empty-command.zsh
@@ -30,6 +30,7 @@
 BUFFER='echo; ;'
 
 expected_region_highlight=(
+  "1 4 builtin" # echo
   "5 5 commandseparator" # ;
   "7 7 unknown-token" # ;
 )

--- a/highlighters/main/test-data/empty-command2.zsh
+++ b/highlighters/main/test-data/empty-command2.zsh
@@ -33,6 +33,7 @@ touch ';'
 BUFFER='echo; ;'
 
 expected_region_highlight=(
+  "1 4 builtin" # echo
   "5 5 commandseparator" # ;
   "7 7 unknown-token" # ;
 )

--- a/highlighters/main/test-data/escaped-single-quote.zsh
+++ b/highlighters/main/test-data/escaped-single-quote.zsh
@@ -32,7 +32,7 @@ BUFFER=$': \'foo\'\\\'\'bar\'' # <<<: 'foo'\''bar'>>>
 
 expected_region_highlight=(
   '1 1 builtin' # :
+  '3 14 default' # 'foo'\''bar'
   '3 7 single-quoted-argument' # 'foo'
-  '8 9 default' # \'
   '10 14 single-quoted-argument' # 'bar'
 )

--- a/highlighters/main/test-data/function.zsh
+++ b/highlighters/main/test-data/function.zsh
@@ -37,5 +37,6 @@ BUFFER='cd;ls'
 
 expected_region_highlight=(
   "1 2 function" # cd
+  "3 3 commandseparator" # ;
   "4 5 function" # ls
 )

--- a/highlighters/main/test-data/glob.zsh
+++ b/highlighters/main/test-data/glob.zsh
@@ -31,11 +31,11 @@ BUFFER=': foo* bar? *baz qux\?'
 
 expected_region_highlight=(
   "1 1 builtin" # :
-  "3 5 default" # foo
+  "3 6 default" # foo*
   "6 6 globbing" # *
-  "8 10 default" # bar
+  "8 11 default" # bar?
   "11 11 globbing" # ?
+  "13 16 default" # *baz
   "13 13 globbing" # *
-  "14 16 default" # baz
   "18 22 default" # qux\?
 )

--- a/highlighters/main/test-data/globs-with-quoting.zsh
+++ b/highlighters/main/test-data/globs-with-quoting.zsh
@@ -32,6 +32,7 @@ BUFFER=$': "foo"*\'bar\'?"baz?"<17-29>"qu*ux"'
 
 expected_region_highlight=(
   '1 1 builtin' # :
+  '3 34 default' # "foo"*'bar'?"baz?"<17-29>"qu*ux"
   '3 7 double-quoted-argument' # "foo"
   '8 8 globbing' # *
   '9 13 single-quoted-argument' # 'bar'

--- a/highlighters/main/test-data/history-double-quoted-escaped.zsh
+++ b/highlighters/main/test-data/history-double-quoted-escaped.zsh
@@ -32,7 +32,7 @@ BUFFER='echo "Hello\!"'
 
 expected_region_highlight=(
   '1 4 builtin' # echo
-  '6 11 double-quoted-argument' # "Hello
+  '6 14 default' # "Hello\!"
+  '6 14 double-quoted-argument' # "Hello\!"
   '12 13 back-double-quoted-argument' # \!
-  '14 14 double-quoted-argument' # "Hello\!"
 )

--- a/highlighters/main/test-data/history-double-quoted-no.zsh
+++ b/highlighters/main/test-data/history-double-quoted-no.zsh
@@ -32,5 +32,6 @@ BUFFER='echo "foo != bar !{baz}"'
 
 expected_region_highlight=(
   '1 4 builtin' # echo
+  '6 24 default' # "foo != bar !{baz}"
   '6 24 double-quoted-argument' # "foo != bar !{baz}" - no history expansions
 )

--- a/highlighters/main/test-data/history-double-quoted-unescaped.zsh
+++ b/highlighters/main/test-data/history-double-quoted-unescaped.zsh
@@ -32,7 +32,7 @@ BUFFER='echo "Hello!"'
 
 expected_region_highlight=(
   '1 4 builtin' # echo
-  '6 11 double-quoted-argument' # "Hello
+  '6 13 default' # "Hello!"
+  '6 13 double-quoted-argument' # "Hello!"
   '12 12 history-expansion' # !
-  '13 13 double-quoted-argument' # "
 )

--- a/highlighters/main/test-data/history-double-quoted-yes.zsh
+++ b/highlighters/main/test-data/history-double-quoted-yes.zsh
@@ -32,7 +32,7 @@ BUFFER='echo "foo !bar"'
 
 expected_region_highlight=(
   '1 4 builtin' # echo
-  '6 10 double-quoted-argument' # "foo 
+  '6 15 default' # "foo !bar"
+  '6 15 double-quoted-argument' # "foo !bar"
   '11 11 history-expansion' # !
-  '12 15 double-quoted-argument' # bar"
 )

--- a/highlighters/main/test-data/history-expansion.zsh
+++ b/highlighters/main/test-data/history-expansion.zsh
@@ -33,6 +33,7 @@ expected_region_highlight=(
   "1 4 history-expansion" # !foo
   "6 8 default" # bar
   "10 13 history-expansion" # !baz
-  "15 15 default" # ! (before the semicolon)
-  "19 19 reserved-word" # ! (after the semicolon)
+  "15 15 default" # !
+  "17 17 commandseparator" # ;
+  "19 19 reserved-word" # !
 )

--- a/highlighters/main/test-data/multiline-string.zsh
+++ b/highlighters/main/test-data/multiline-string.zsh
@@ -31,6 +31,7 @@ PREBUFFER=$'echo "foo1\n'
 BUFFER='foo2" ./'
 
 expected_region_highlight=(
+  "1 5 default" # 'foo2"'
   "1 5 double-quoted-argument" # 'foo2"'
   "7 8 path" # './'
 )

--- a/highlighters/main/test-data/multiline-string2.zsh
+++ b/highlighters/main/test-data/multiline-string2.zsh
@@ -30,5 +30,7 @@
 BUFFER=$'echo \'foo1\n'
 
 expected_region_highlight=(
-  "6 10 single-quoted-argument-unclosed" # 'foo1
+  "1 4 builtin" # echo
+  "6 11 default" # 'foo1\n
+  "6 11 single-quoted-argument-unclosed" # 'foo1\n
 )

--- a/highlighters/main/test-data/multiple-quotes.zsh
+++ b/highlighters/main/test-data/multiple-quotes.zsh
@@ -30,18 +30,13 @@
 BUFFER=$': \'foo\'bar"baz$quux/foo\\\\bar"baz$\'quux\\nfoo\\001bar\'baz'
 
 expected_region_highlight=(
+  "1 1 builtin" # :
+  "3 54 default" # 'foo'bar"baz$quux/foo\\bar"baz$'quux\nfoo\001'baz
   "3 7 single-quoted-argument" # 'foo'
-  "8 10 default" # bar
-  "11 14 double-quoted-argument" #"baz
+  "11 29 double-quoted-argument" #"baz
   "15 19 dollar-double-quoted-argument" # $quux
-  "20 23 double-quoted-argument" # /foo
   "24 25 back-double-quoted-argument" # \\
-  "26 29 double-quoted-argument" # bar"
-  "30 32 default" # baz
-  "33 38 dollar-quoted-argument" # $'quux
+  "33 51 dollar-quoted-argument" # $'quux\nfoo\001bar'
   "39 40 back-dollar-quoted-argument" # \n
-  "41 43 dollar-quoted-argument" # foo
   "44 47 back-dollar-quoted-argument" # \001
-  "48 51 dollar-quoted-argument" # bar'
-  "52 54 default" # baz
 )

--- a/highlighters/main/test-data/noglob-alias.zsh
+++ b/highlighters/main/test-data/noglob-alias.zsh
@@ -31,5 +31,6 @@ alias x=command
 BUFFER='x ls'
 
 expected_region_highlight=(
+  "1 1 alias" # x
   "3 4 command" # ls
 )

--- a/highlighters/main/test-data/noglob1.zsh
+++ b/highlighters/main/test-data/noglob1.zsh
@@ -30,5 +30,9 @@
 BUFFER=':; noglob echo *'
 
 expected_region_highlight=(
+  "1 1 builtin" # :
+  "2 2 commandseparator" # ;
+  "4 9 precommand" # noglob
+  "11 14 builtin" # echo
   "16 16 default" # *
 )

--- a/highlighters/main/test-data/noglob2.zsh
+++ b/highlighters/main/test-data/noglob2.zsh
@@ -30,6 +30,11 @@
 BUFFER='noglob echo *; echo *'
 
 expected_region_highlight=(
+  "1 6 precommand" # noglob
+  "8 11 builtin" # echo
   "13 13 default" # *
+  "14 14 commandseparator" # ;
+  "16 19 builtin" # echo
+  "21 21 default" # *
   "21 21 globbing" # *
 )

--- a/highlighters/main/test-data/noglob3.zsh
+++ b/highlighters/main/test-data/noglob3.zsh
@@ -32,5 +32,7 @@ touch \*
 BUFFER='noglob echo *'
 
 expected_region_highlight=(
+  "1 6 precommand" # noglob
+  "8 11 builtin" # echo
   "13 13 path" # *
 )

--- a/highlighters/main/test-data/number_range-glob.zsh
+++ b/highlighters/main/test-data/number_range-glob.zsh
@@ -32,10 +32,10 @@ BUFFER='print <-> x<->y <foo2-3>'
 
 expected_region_highlight=(
   '1 5 builtin' # print
+  '7 9 default' # <->
   '7 9 globbing' # <->
-  '11 11 default' # x
+  '11 15 default' # x<->y
   '12 14 globbing' # <->
-  '15 15 default' # y
   '17 17 redirection' # <
   '18 23 default' # foo2-3 (the filename)
   '24 24 redirection' # >

--- a/highlighters/main/test-data/option-with-quotes.zsh
+++ b/highlighters/main/test-data/option-with-quotes.zsh
@@ -32,6 +32,6 @@ BUFFER=$': --user="phy1729"'
 
 expected_region_highlight=(
   '1 1 builtin' # :
-  '3 9 double-hyphen-option' # --user=
+  '3 18 double-hyphen-option' # --user="phy1729"
   '10 18 double-quoted-argument' # "phy1729"
 )

--- a/highlighters/main/test-data/order-path-before-globbing.zsh
+++ b/highlighters/main/test-data/order-path-before-globbing.zsh
@@ -33,6 +33,7 @@ BUFFER=': * \*'
 
 expected_region_highlight=(
   '1 1 builtin' # :
+  '3 3 default' # *
   '3 3 globbing' # *
   '5 6 path' # \*
 )

--- a/highlighters/main/test-data/parameter-star.zsh
+++ b/highlighters/main/test-data/parameter-star.zsh
@@ -32,5 +32,9 @@ BUFFER='() { : $* }'
 # This tests that $* isn't highlighted as a glob.
 # If we ever add a "unquoted parameter" style, the expectation may change.
 expected_region_highlight=(
+  "1 2 reserved-word" # ()
+  "4 4 reserved-word" # {
+  "6 6 builtin" # :
   "8 9 default" # $*
+  "11 11 reserved-word" # }
 )

--- a/highlighters/main/test-data/path-broken-symlink.zsh
+++ b/highlighters/main/test-data/path-broken-symlink.zsh
@@ -35,6 +35,7 @@ else
   CURSOR=5 # to make path_prefix ineligible
 
   expected_region_highlight=(
+    "1 1 builtin" # :
     "3 16 path" # broken-symlink
   )
 fi

--- a/highlighters/main/test-data/path-dollared-word2.zsh
+++ b/highlighters/main/test-data/path-dollared-word2.zsh
@@ -32,5 +32,6 @@ touch \$lambda
 BUFFER=': \$lambda'
 
 expected_region_highlight=(
-  "3 8 path" # \$lambda
+  "1 1 builtin" # :
+  "3 10 path" # \$lambda
 )

--- a/highlighters/main/test-data/path-dollared-word3.zsh
+++ b/highlighters/main/test-data/path-dollared-word3.zsh
@@ -33,5 +33,6 @@ BUFFER='$PWD; ${PWD}'
 
 expected_region_highlight=(
   "1 4 unknown-token" # $PWD - not eval'd; issue #328
+  "5 5 commandseparator" # ;
   "7 12 unknown-token" # ${PWD}
 )

--- a/highlighters/main/test-data/path-separators.zsh
+++ b/highlighters/main/test-data/path-separators.zsh
@@ -37,17 +37,17 @@ touch A/mu
 BUFFER='ls /bin/ / A/mu A/m'
 
 expected_region_highlight=(
+  "1 2 command"                      # ls
+  "4 8 path"                         # /bin/
   "4 4 path_pathseparator"           # /
-  "5 7 path"                         # bin
   "8 8 path_pathseparator"           # /
 
+  "10 10 path"                       # /
   "10 10 path_pathseparator"         # /
 
-  "12 12 path"                       # A
+  "12 15 path"                       # A/mu
   "13 13 path_pathseparator"         # /
-  "14 15 path"                       # mu
 
-  "17 17 path_prefix"                # A
+  "17 19 path_prefix"                # A/m
   "18 18 path_prefix_pathseparator"  # /
-  "19 19 path_prefix"                # m
 )

--- a/highlighters/main/test-data/path-separators2.zsh
+++ b/highlighters/main/test-data/path-separators2.zsh
@@ -35,5 +35,6 @@ ZSH_HIGHLIGHT_STYLES[path_pathseparator]=value
 BUFFER='ls /bin/'
 
 expected_region_highlight=(
+  "1 2 command" # ls
   "4 8 path"    # /bin/
 )

--- a/highlighters/main/test-data/path-space.zsh
+++ b/highlighters/main/test-data/path-space.zsh
@@ -33,5 +33,5 @@ BUFFER='ls A/mu\ with\ spaces'
 
 expected_region_highlight=(
   "1 2  command" # ls
-  "4 19 path"    # A/mu\ with\ spaces
+  "4 21 path"    # A/mu\ with\ spaces
 )

--- a/highlighters/main/test-data/path_prefix.zsh
+++ b/highlighters/main/test-data/path_prefix.zsh
@@ -33,5 +33,6 @@
 BUFFER='ls /bin/s'
 
 expected_region_highlight=(
-  "4 9 path_prefix"    # /bin/s
+  "1 2 command" # ls
+  "4 9 path_prefix" # /bin/s
 )

--- a/highlighters/main/test-data/path_prefix2.zsh
+++ b/highlighters/main/test-data/path_prefix2.zsh
@@ -34,5 +34,6 @@ BUFFER='ls /bin/s'
 WIDGET=zle-line-finish
 
 expected_region_highlight=(
-  "4 9 default"    # /bin/s
+  "1 2 command" # ls
+  "4 9 default" # /bin/s
 )

--- a/highlighters/main/test-data/prefix-redirection.zsh
+++ b/highlighters/main/test-data/prefix-redirection.zsh
@@ -30,10 +30,13 @@
 BUFFER='>/tmp >/tmp command echo >/tmp foo'
 
 expected_region_highlight=(
+  "1  1  redirection" # >
   "2  5  path"       # /tmp
+  "7  7  redirection" # >
   "8  11 path"       # /tmp
   "13 19 precommand" # command
   "21 24 builtin"    # echo
+  "26 26 redirection" # >
   "27 30 path"       # /tmp
   "32 34 default"    # foo
 )

--- a/highlighters/main/test-data/rc-quotes.zsh
+++ b/highlighters/main/test-data/rc-quotes.zsh
@@ -32,8 +32,8 @@ setopt RC_QUOTES
 BUFFER=": 'foo''bar'baz"
 
 expected_region_highlight=(
-  "3 6 single-quoted-argument" # 'foo
+  "1 1 builtin" # :
+  "3 15 default" # 'foo''bar'baz
+  "3 12 single-quoted-argument" # 'foo''bar'
   "7 8 rc-quote" # ''
-  "9 12 single-quoted-argument" # bar'
-  "13 15 default" # baz
 )

--- a/highlighters/main/test-data/redirection.zsh
+++ b/highlighters/main/test-data/redirection.zsh
@@ -32,5 +32,8 @@ BUFFER='<<<foo echo >>&!bar'
 
 expected_region_highlight=(
   "1 3 redirection" # <<<
+  "4 6 default" # foo
+  "8 11 builtin" # echo
   "13 16 redirection" # >>&!
+  "17 19 default" # bar
 )

--- a/highlighters/main/test-data/reserved-word.zsh
+++ b/highlighters/main/test-data/reserved-word.zsh
@@ -31,6 +31,7 @@ BUFFER='repeat "1" do done'
 
 expected_region_highlight=(
   "1 6 reserved-word" # repeat
+  "8 10 default" # "1"
   "8 10 double-quoted-argument" # "1"
   "12 13 reserved-word" # do
   "15 18 reserved-word" # done

--- a/highlighters/main/test-data/subshell.zsh
+++ b/highlighters/main/test-data/subshell.zsh
@@ -31,10 +31,20 @@ BUFFER='tar cf - * | (cd /target; tar xfp -) | { cat }'
 
 expected_region_highlight=(
   "1 3 command" # tar
+  "5 6 default" # cf
+  "8 8 single-hyphen-option" # -
+  "10 10 default" # *
+  "10 10 globbing" # *
+  "12 12 commandseparator" # |
   "14 14 reserved-word" # (
   "15 16 builtin" # cd
+  "18 24 default" # /target
+  "25 25 commandseparator" # ;
   "27 29 command" # tar
+  "31 33 default" # xfp
+  "35 35 single-hyphen-option" # -
   "36 36 reserved-word" # )
+  "38 38 commandseparator" # |
   "40 40 reserved-word" # {
   "42 44 command" # cat
   "46 46 reserved-word" # }

--- a/highlighters/main/test-data/sudo-command.zsh
+++ b/highlighters/main/test-data/sudo-command.zsh
@@ -43,7 +43,12 @@ expected_region_highlight=(
   "23 24 single-hyphen-option" # -i
   "26 27 command" # ls
   "29 29 path" # /
+  "30 30 commandseparator" # ;
+  "32 35 precommand" # sudo
   "37 37 unknown-token" # ;, error because empty command
+  "39 42 precommand" # sudo
+  "44 45 single-hyphen-option" # -u
   "47 47 unknown-token" # ;, error because incomplete command
+  "49 52 precommand" # sudo
   "54 64 unknown-token" # notacommand - doesn't falls back to "not a command word" codepath
 )

--- a/highlighters/main/test-data/vi-linewise-mode.zsh
+++ b/highlighters/main/test-data/vi-linewise-mode.zsh
@@ -34,5 +34,10 @@ CURSOR=4
 MARK=12
 
 expected_region_highlight=(
-  "1 3 standout" # foo
+  "1 3 unknown-token" # foo
+  "5 7 default" # foo
+  "8 8 commandseparator" # \n
+  "9 11 unknown-token" # bar
+  "13 15 default" # bar
+  "1 15 standout" # foo foo\nbar bar
 )

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,12 +13,13 @@ The value of that parameter is a list of strings of the form  `"$i $j $style"`.
 or `"$i $j $style $todo"`.
 Each string specifies the highlighting that `$BUFFER[$i,$j]` should have;
 that is, `$i` and `$j` specify a range, 1-indexed, inclusive of both endpoints.
-`$style` is either a key of `$ZSH_HIGHLIGHT_STYLES` or `NONE` to specify no
-highlighting should be observed.
+`$style` is a key of `$ZSH_HIGHLIGHT_STYLES`.
 If `$todo` exists, the test point is marked as TODO (the failure of that test
 point will not fail the test), and `$todo` is used as the explanation.
 If a test sets `$skip_test` to a non-empty string, the test will be skipped
 with the provided string as the reason.
+If a test sets `unsorted=1` the order of highlights in `$expected_region_highlight`
+need not match the order in `$region_highlight`.
 
 **Note**: `$region_highlight` uses the same `"$i $j $style"` syntax but
 interprets the indexes differently.

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -141,7 +141,7 @@ _zsh_highlight()
         {
           "_zsh_highlight_highlighter_${highlighter}_paint"
         } always {
-          eval "${cache_place}=(\"\${region_highlight[@]}\")"
+          : ${(AP)cache_place::="${region_highlight[@]}"}
         }
 
         # Restore saved region_highlight
@@ -150,7 +150,7 @@ _zsh_highlight()
       fi
 
       # Use value form cache if any cached
-      eval "region_highlight+=(\"\${${cache_place}[@]}\")"
+      region_highlight+=("${(@P)cache_place}")
 
     done
 

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -168,8 +168,10 @@ _zsh_highlight()
         else
           min=$MARK max=$CURSOR
         fi
-        (( min = ${${BUFFER[1,$min]}[(I)$needle]} ))
-        (( max += ${${BUFFER:($max-1)}[(i)$needle]} - 1 ))
+        # CURSOR and MARK are 0 indexed between letters like region_highlight
+        # Do not include the newline in the highlight
+        (( min = ${BUFFER[(Ib:min:)$needle]} ))
+        (( max = ${BUFFER[(ib:max:)$needle]} - 1 ))
         _zsh_highlight_apply_zle_highlight region standout "$min" "$max"
       }
     fi


### PR DESCRIPTION
Still has a few TODOs

- [x] comment-followed: Should the newline ending a comment be considered a `commandseparator`?
- [x] redirections2: What style should `>(wc)` be?
- [x] vanilla-newline: Unexpected entry `"0 0 unknown-token"`. Seems to be due to the last newline in `$PREBUFFER`.
- [x] vi-linewise-mode: I think that standout should be 1 15, but I'm not sure.
- [x] -unclosed styles are off by one.