### PR TITLE
'main': Don't highlight bare '$foo' as a filename, as it's a parameter expansion.

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -823,7 +823,9 @@ _zsh_highlight_main_highlighter_highlight_argument()
         highlights+=($reply)
         ;;
       '$')
+        path_eligible=0
         if [[ $arg[i+1] == "'" ]]; then
+          path_eligible=1
           _zsh_highlight_main_highlighter_highlight_dollar_quote $i
           (( i = REPLY ))
           highlights+=($reply)

--- a/highlighters/main/test-data/order-path-after-dollar.zsh
+++ b/highlighters/main/test-data/order-path-after-dollar.zsh
@@ -33,6 +33,6 @@ BUFFER=': $foo \$foo'
 
 expected_region_highlight=(
   '1 1 builtin' # :
-  '3 6 default "issue #474"' # $foo - if we add a "unquoted parameter expansion" style then this expectation should change
+  '3 6 default' # $foo - if we add a "unquoted parameter expansion" style then this expectation should change
   '8 12 path' # \$foo
 )


### PR DESCRIPTION
Fixes #474.