### PR TITLE
main: Add ZSH_HIGHLIGHT_DIRS_BLACKLIST

### DIFF
--- a/docs/highlighters/main.md
+++ b/docs/highlighters/main.md
@@ -71,6 +71,12 @@ The syntax for values is the same as the syntax of "types of highlighting" of
 the zsh builtin `$zle_highlight` array, which is documented in [the `zshzle(1)`
 manual page][zshzle-Character-Highlighting].
 
+#### Parameters
+
+To avoid partial path lookups on a path, add the path to the `ZSH_HIGHLIGHT_DIRS_BLACKLIST` array.
+
+    ZSH_HIGHLIGHT_DIRS_BLACKLIST+=(/mnt/slow_share)
+
 ### Useless trivia
 
 #### Forward compatibility.

--- a/docs/highlighters/main.md
+++ b/docs/highlighters/main.md
@@ -73,9 +73,10 @@ manual page][zshzle-Character-Highlighting].
 
 #### Parameters
 
-To avoid partial path lookups on a path, add the path to the `ZSH_HIGHLIGHT_DIRS_BLACKLIST` array.
+To avoid partial path lookups on a path, add the path to the `X_ZSH_HIGHLIGHT_DIRS_BLACKLIST` array.
+This interface is still experimental.
 
-    ZSH_HIGHLIGHT_DIRS_BLACKLIST+=(/mnt/slow_share)
+    X_ZSH_HIGHLIGHT_DIRS_BLACKLIST+=(/mnt/slow_share)
 
 ### Useless trivia
 

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -757,13 +757,26 @@ _zsh_highlight_main_highlighter_highlight_path_separators()
 _zsh_highlight_main_highlighter_check_path()
 {
   _zsh_highlight_main_highlighter_expand_path $arg;
-  local expanded_path="$REPLY"
+  local expanded_path="$REPLY" tmp_path
 
   REPLY=path
 
   [[ -z $expanded_path ]] && return 1
   [[ -L $expanded_path ]] && return 0
   [[ -e $expanded_path ]] && return 0
+
+  # Check if this is a blacklisted path
+  if [[ $expanded_path[1] == / ]]; then
+    tmp_path=$expanded_path
+  else
+    tmp_path=$PWD/$expanded_path
+  fi
+  tmp_path=$tmp_path:a
+
+  while [[ $tmp_path != / ]]; do
+    [[ -n "${(M)ZSH_HIGHLIGHT_DIRS_BLACKLIST:#$tmp_path}" ]] && return 1
+    tmp_path=$tmp_path:h
+  done
 
   # Search the path in CDPATH
   local cdpath_dir
@@ -1070,3 +1083,4 @@ else
   # Make sure the cache is unset
   unset _zsh_highlight_main__command_type_cache
 fi
+typeset -ga ZSH_HIGHLIGHT_DIRS_BLACKLIST

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -774,7 +774,7 @@ _zsh_highlight_main_highlighter_check_path()
   tmp_path=$tmp_path:a
 
   while [[ $tmp_path != / ]]; do
-    [[ -n "${(M)ZSH_HIGHLIGHT_DIRS_BLACKLIST:#$tmp_path}" ]] && return 1
+    [[ -n "${(M)X_ZSH_HIGHLIGHT_DIRS_BLACKLIST:#$tmp_path}" ]] && return 1
     tmp_path=$tmp_path:h
   done
 
@@ -1083,4 +1083,4 @@ else
   # Make sure the cache is unset
   unset _zsh_highlight_main__command_type_cache
 fi
-typeset -ga ZSH_HIGHLIGHT_DIRS_BLACKLIST
+typeset -ga X_ZSH_HIGHLIGHT_DIRS_BLACKLIST

--- a/highlighters/main/test-data/dirs_blacklist.zsh
+++ b/highlighters/main/test-data/dirs_blacklist.zsh
@@ -1,0 +1,40 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2018 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+mkdir foo
+touch foo/bar
+BUFFER=": foo/bar $PWD/foo foo/b"
+ZSH_HIGHLIGHT_DIRS_BLACKLIST=($PWD/foo)
+
+expected_region_highlight=(
+  '1 1 builtin' # :
+  '3 9 path' # foo/bar
+  "11 $(( 14 + $#PWD )) path" # $PWD/foo
+  "$(( 16 + $#PWD )) $(( 20 + $#PWD )) default" # foo/b
+)

--- a/highlighters/main/test-data/dirs_blacklist.zsh
+++ b/highlighters/main/test-data/dirs_blacklist.zsh
@@ -30,7 +30,7 @@
 mkdir foo
 touch foo/bar
 BUFFER=": foo/bar $PWD/foo foo/b"
-ZSH_HIGHLIGHT_DIRS_BLACKLIST=($PWD/foo)
+X_ZSH_HIGHLIGHT_DIRS_BLACKLIST=($PWD/foo)
 
 expected_region_highlight=(
   '1 1 builtin' # :


### PR DESCRIPTION
Closes #379.

This may fail on symlinks, but I think this should cover most cases. I placed the check below the -L and -e tests so once the file is completely typed it will still highlight as path.

_Please test_ that the speed with this change is usable if you've run into #379. If things are still too slow the check can be moved up (or we could test that the word is no longer being typed with `$CURSOR` and have a cache).

I'll add docs after we get some reports and know how `$ZSH_HIGHLIGHT_DIRS_BLACKLIST` will act.