### PR TITLE
fix _zsh_highlight_load_highlighters when executing zsh with sudo rights

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -373,7 +373,7 @@ _zsh_highlight_load_highlighters()
 
   # Load highlighters from highlighters directory and check they define required functions.
   local highlighter highlighter_dir
-  for highlighter_dir ($1/*/); do
+  for highlighter_dir ($1/*/(/)); do
     highlighter="${highlighter_dir:t}"
     [[ -f "$highlighter_dir${highlighter}-highlighter.zsh" ]] &&
       . "$highlighter_dir${highlighter}-highlighter.zsh"


### PR DESCRIPTION
I am facing following error message if i start my zsh with sudo right e.g. `sudo zsh`

**Error Log**
_zsh-syntax-highlighting: 'README.md' highlighter should define both required functions '_zsh_highlight_highlighter_README.md_paint' and '_zsh_highlight_highlighter_README.md_predicate' in '/Users/USERNAME/.zsh.zgem/gems/zsh-syntax-highlighting/highlighters/README.md/README.md-highlighter.zsh'._

this is caused by a really strange behaviour of zsh itself.

**ZSH Issue Example**

If you create a file and folder

```
mkdir -p folder
touch file
```

...,if you want to print only folders globing works as expected
```
echo ./*/
>> ./folder/
```

..., however if you run the same command with sudo it will also print the file, as a folder.
thats totally weird.
```
sudo zsh -c 'echo ./*/'
>> ./file/ ./folder/
```


**Solution**

Because thats a zsh issue I adjust the globing expression, now it works as expected.