### PR TITLE
Add instructions about initializing variable

### DIFF
--- a/docs/highlighters.md
+++ b/docs/highlighters.md
@@ -27,7 +27,11 @@ To activate an highlighter, add it to the `ZSH_HIGHLIGHT_HIGHLIGHTERS` array in
     ZSH_HIGHLIGHT_HIGHLIGHTERS=(main brackets pattern cursor)
 
 By default, `$ZSH_HIGHLIGHT_HIGHLIGHTERS` is unset and only the `main`
-highlighter is active.
+highlighter is active. 
+
+If you would like to set this variable before
+sourcing zsh-syntax-highlighting, initialize it first with: 
+`typeset -ga ZSH_HIGHLIGHT_HIGHLIGHTERS`
 
 
 How to tweak highlighters


### PR DESCRIPTION
Many users use modular configuration loaders for zshrc. Adding a note to users explaining how to define ZSH_HIGHLIGHT_HIGHLIGHTERS before sourcing zsh-syntax-highlighting. The typeset is important, since simply setting the variable doesn't have the desired effect.