### PR TITLE
main-highlighter.zsh: Probe dirs after blacklist

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -761,8 +761,6 @@ _zsh_highlight_main_highlighter_check_path()
   REPLY=path
 
   [[ -z $expanded_path ]] && return 1
-  [[ -L $expanded_path ]] && return 0
-  [[ -e $expanded_path ]] && return 0
 
   # Check if this is a blacklisted path
   if [[ $expanded_path[1] == / ]]; then
@@ -776,6 +774,9 @@ _zsh_highlight_main_highlighter_check_path()
     [[ -n "${(M)X_ZSH_HIGHLIGHT_DIRS_BLACKLIST:#$tmp_path}" ]] && return 1
     tmp_path=$tmp_path:h
   done
+
+  [[ -L $expanded_path ]] && return 0
+  [[ -e $expanded_path ]] && return 0
 
   # Search the path in CDPATH
   local cdpath_dir

--- a/highlighters/main/test-data/dirs_blacklist.zsh
+++ b/highlighters/main/test-data/dirs_blacklist.zsh
@@ -34,7 +34,7 @@ X_ZSH_HIGHLIGHT_DIRS_BLACKLIST=($PWD/foo)
 
 expected_region_highlight=(
   '1 1 builtin' # :
-  '3 9 path' # foo/bar
-  "11 $(( 14 + $#PWD )) path" # $PWD/foo
+  '3 9 default' # foo/bar
+  "11 $(( 14 + $#PWD )) default" # $PWD/foo
   "$(( 16 + $#PWD )) $(( 20 + $#PWD )) default" # foo/b
 )


### PR DESCRIPTION
Move tests on the highlight path until after the blacklist is checked so
that blacklisted paths are not tested. This should prevent hangs on dead
remote filesystems provided the path is blacklisted in
X_ZSH_HIGHLIGHT_DIRS_BLACKLIST.

Bug: https://github.com/zsh-users/zsh-syntax-highlighting/issues/528