### PR TITLE
Use shallow clone while installing

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,7 +33,7 @@ See also [repology's cross-distro index](https://repology.org/metapackage/zsh-sy
 
 Simply clone this repository and source the script:
 
-    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git
+    git clone --depth 1 https://github.com/zsh-users/zsh-syntax-highlighting.git
     echo "source ${(q-)PWD}/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" >> ${ZDOTDIR:-$HOME}/.zshrc
 
   Then, enable syntax highlighting in the current interactive shell:
@@ -69,7 +69,7 @@ your `.zshrc`.
 
 1. Clone this repository in oh-my-zsh's plugins directory:
 
-       git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+       git clone --depth 1 https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
 
 2. Activate the plugin in `~/.zshrc`:
 


### PR DESCRIPTION
Takes much less time on a slow connection.
Also, it doesn't seem practical to have complete commit history for installation purposes.