### PR TITLE
Parse full alias

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -533,20 +533,20 @@ _zsh_highlight_main_highlighter_highlight_list()
       local res="$REPLY"
       if [[ $res == "alias" ]]; then
         () {
-        local -A seen_arg
+        local -A seen_alias
         while [[ $REPLY == alias ]]; do
-        seen_arg[$arg]=1
+        seen_alias[$arg]=1
         _zsh_highlight_main__resolve_alias $arg
         # Use a temporary array to ensure the subscript is interpreted as
         # an array subscript, not as a scalar subscript
-        local -a reply
+        local -a alias_args
         # TODO: the ${interactive_comments+set} path needs to skip comments; see test-data/alias-comment1.zsh
-        reply=( ${interactive_comments-${(z)REPLY}}
-                ${interactive_comments+${(zZ+c+)REPLY}} )
+        alias_args=( ${interactive_comments-${(z)REPLY}}
+                     ${interactive_comments+${(zZ+c+)REPLY}} )
         # Avoid looping forever on alias a=b b=c c=b, but allow alias foo='foo bar'
-        [[ $arg == $reply[1] ]] && break
-        arg=$reply[1]
-        if (( $+seen_arg[$arg] )); then
+        [[ $arg == $alias_args[1] ]] && break
+        arg=$alias_args[1]
+        if (( $+seen_alias[$arg] )); then
           res=none
           break
         fi

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -400,9 +400,11 @@ _zsh_highlight_main_highlighter_highlight_list()
   else
     args=(${(z)buf})
   fi
-  for arg in $args; do
+  while (( $#args )); do
     # Save an unmunged copy of the current word.
+    arg=$args[1]
     arg_raw="$arg"
+    shift args
 
     # Initialize this_word and next_word.
     if (( in_redirection == 0 )); then

--- a/highlighters/main/test-data/alias-comment2.zsh
+++ b/highlighters/main/test-data/alias-comment2.zsh
@@ -33,5 +33,6 @@ alias x=$'# foo\npwd'
 BUFFER='x'
 
 expected_region_highlight=(
-  "1 1 unknown-token" # x becomes #
+  '1 1 alias' # x
+  '1 1 unknown-token' # x (#)
 )

--- a/highlighters/main/test-data/alias-complex.zsh
+++ b/highlighters/main/test-data/alias-complex.zsh
@@ -1,0 +1,39 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2018 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+alias x='echo && ls; >'
+
+BUFFER='x file echo'
+
+expected_region_highlight=(
+  '1 1 alias' # x
+  '1 1 builtin' # x (echo)
+  '3 6 default' # file
+  '8 11 builtin' # echo
+)

--- a/highlighters/main/test-data/alias-empty.zsh
+++ b/highlighters/main/test-data/alias-empty.zsh
@@ -1,0 +1,38 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2018 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+alias x=''
+
+BUFFER='x echo foo'
+
+expected_region_highlight=(
+  '1 1 alias' # x
+  '3 6 builtin' # echo
+  '8 10 default' # foo
+)

--- a/highlighters/main/test-data/alias-loop.zsh
+++ b/highlighters/main/test-data/alias-loop.zsh
@@ -33,7 +33,8 @@ alias a=b b=c c=b
 BUFFER='a foo; :'
 
 expected_region_highlight=(
-  '1 1 unknown-token' # a
+  '1 1 alias' # a
+  '1 1 unknown-token' # a (invalid alias loop)
   '3 5 default' # foo
   '6 6 commandseparator' # ;
   '8 8 builtin' # :

--- a/highlighters/main/test-data/alias-nested-precommand.zsh
+++ b/highlighters/main/test-data/alias-nested-precommand.zsh
@@ -35,6 +35,7 @@ BUFFER='a -u phy1729 echo; :'
 
 expected_region_highlight=(
   '1 1 alias' # a
+  '1 1 precommand' # a (sudo)
   '3 4 single-hyphen-option' # -u
   '6 12 default' # phy1729
   '14 17 builtin' # echo

--- a/highlighters/main/test-data/alias-nested.zsh
+++ b/highlighters/main/test-data/alias-nested.zsh
@@ -34,6 +34,7 @@ BUFFER='a foo; :'
 
 expected_region_highlight=(
   '1 1 alias' # a
+  '1 1 builtin' # a (:)
   '3 5 default' # foo
   '6 6 commandseparator' # ;
   '8 8 builtin' # :

--- a/highlighters/main/test-data/alias-precommand-option-argument1.zsh
+++ b/highlighters/main/test-data/alias-precommand-option-argument1.zsh
@@ -1,5 +1,6 @@
+#!/usr/bin/env zsh
 # -------------------------------------------------------------------------------------------------
-# Copyright (c) 2016 zsh-syntax-highlighting contributors
+# Copyright (c) 2018 zsh-syntax-highlighting contributors
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted
@@ -27,12 +28,15 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
-# see alias-comment2.zsh
-setopt interactivecomments
-alias x=$'# foo\npwd'
-BUFFER='x'
+alias sdu='sudo -u'
+sudo(){}
+
+BUFFER='sdu phy1729 echo foo'
 
 expected_region_highlight=(
-  '1 1 alias' # x
-  '1 1 comment' # x (#)
+  '1 3 alias' # sdu
+  '1 3 precommand' # sdu (sudo)
+  '5 11 default' # phy1729
+  '13 16 commmand "issue #540"' # echo (not builtin)
+  '18 20 default' # foo
 )

--- a/highlighters/main/test-data/alias-precommand-option-argument2.zsh
+++ b/highlighters/main/test-data/alias-precommand-option-argument2.zsh
@@ -28,14 +28,16 @@
 # vim: ft=zsh sw=2 ts=2 et
 # -------------------------------------------------------------------------------------------------
 
-alias sdu='sudo -u'
+alias sde='sudo -e'
+alias seu='sde -u'
 sudo(){}
 
-BUFFER='sdu phy1729 echo foo'
+BUFFER='seu phy1729 echo foo'
 
 expected_region_highlight=(
-  '1 3 alias' # sdu
-  '5 11 default "issue #540"' # phy1729
+  '1 3 alias' # seu
+  '1 3 precommand' # seu (sudo)
+  '5 11 default' # phy1729
   '13 16 commmand "issue #540"' # echo (not builtin)
   '18 20 default' # foo
 )

--- a/highlighters/main/test-data/alias-quoted.zsh
+++ b/highlighters/main/test-data/alias-quoted.zsh
@@ -35,5 +35,5 @@ expected_region_highlight=(
   '1 3 unknown-token' # "a"
   '5 7 default' # foo
   '8 8 commandseparator' # ;
-  '10 12 command "issue #544' # \ls
+  '10 12 command' # \ls
 )

--- a/highlighters/main/test-data/alias-redirect.zsh
+++ b/highlighters/main/test-data/alias-redirect.zsh
@@ -31,7 +31,8 @@ alias x=\>
 BUFFER='x foo echo bar'
 
 expected_region_highlight=(
-  '1 1 redirection' # x becomes >
+  '1 1 alias' # x
+  '1 1 redirection' # x (>)
   '3 5 default' # foo
   '7 10 builtin' # echo
   '12 14 default' # bar

--- a/highlighters/main/test-data/alias-self.zsh
+++ b/highlighters/main/test-data/alias-self.zsh
@@ -34,5 +34,6 @@ BUFFER='echo bar'
 
 expected_region_highlight=(
   '1 4 alias' # echo
+  '1 4 builtin' # echo
   '6 8 default' # bar
 )

--- a/highlighters/main/test-data/alias-to-dir.zsh
+++ b/highlighters/main/test-data/alias-to-dir.zsh
@@ -32,5 +32,6 @@ alias x=/
 BUFFER=$'x'
 
 expected_region_highlight=(
-  '1 1 unknown-token' # x
+  '1 1 alias' # x
+  '1 1 unknown-token "issue #202"' # x (/)
 )

--- a/highlighters/main/test-data/alias.zsh
+++ b/highlighters/main/test-data/alias.zsh
@@ -48,4 +48,5 @@ fi
 expected_region_highlight+=(
   "9 9 commandseparator" # ;
   "11 16 alias" # alias1
+  "11 16 command" # alias1 (ls)
 )

--- a/highlighters/main/test-data/noglob-alias.zsh
+++ b/highlighters/main/test-data/noglob-alias.zsh
@@ -32,5 +32,6 @@ BUFFER='x ls'
 
 expected_region_highlight=(
   "1 1 alias" # x
+  "1 1 precommand" # x (command)
   "3 4 command" # ls
 )

--- a/highlighters/main/test-data/off-by-one.zsh
+++ b/highlighters/main/test-data/off-by-one.zsh
@@ -33,8 +33,9 @@ f() {}
 BUFFER='a;f;'
 
 expected_region_highlight=(
-  "1 1 alias" # f
+  "1 1 alias" # a
+  "1 1 builtin" # a (:)
   "2 2 commandseparator" # ;
-  "3 3 function" # g
+  "3 3 function" # f
   "4 4 commandseparator" # ;
 )


### PR DESCRIPTION
This runs the entirety of the alias through the state machine not just the first (z)-word.

There's still an issue when the non-terminal alias has more than one (z)-word, but I don't have the brain power to think through that tonight.

This changes behavior for aliases. An alias will be highlighted as alias and the style appropriate for the first (z)-word of the fully resolved alias.