### PR TITLE
main: Simplify proc_buf offset calculation

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -470,40 +470,11 @@ _zsh_highlight_main_highlighter_highlight_list()
 
     if (( in_alias == 0 )); then
       # Compute the new $start_pos and $end_pos, skipping over whitespace in $buf.
-      start_pos=$end_pos
-      if [[ $arg == ';' ]] ; then
-        # We're looking for either a semicolon or a newline, whichever comes
-        # first.  Both of these are rendered as a ";" (SEPER) by the ${(z)..}
-        # flag.
-        #
-        # We can't use the (Z+n+) flag because that elides the end-of-command
-        # token altogether, so 'echo foo\necho bar' (two commands) becomes
-        # indistinguishable from 'echo foo echo bar' (one command with three
-        # words for arguments).
-        local needle=$'[;\n]'
-        integer offset=$(( ${proc_buf[(i)$needle]} - 1 ))
-        (( start_pos += offset ))
-        (( end_pos = start_pos + $#arg ))
-      else
-        # The line was:
-        #
-        # integer offset=$(((len-start_pos)-${#${proc_buf##([[:space:]]|\\[[:space:]])#}}))
-        #
-        # - len-start_pos is length of current proc_buf; basically: initial length minus where
-        #   we are, and proc_buf is chopped to the "where we are" (compare the "previous value
-        #   of start_pos" below, and the len-(start_pos-offset) = len-start_pos+offset)
-        # - what's after main minus sign is: length of proc_buf without spaces at the beginning
-        # - so what the line actually did, was computing length of the spaces!
-        # - this can be done via (#b) flag, like below
-        if [[ "$proc_buf" = (#b)(#s)(([[:space:]]|\\$'\n')##)* ]]; then
-            # The first, outer parenthesis
-            integer offset="${#match[1]}"
-        else
-            integer offset=0
-        fi
-        ((start_pos+=offset))
-        ((end_pos=$start_pos+${#arg}))
-      fi
+      [[ "$proc_buf" = (#b)(#s)(([ $'\t']|\\$'\n')#)* ]]
+      # The first, outer parenthesis
+      integer offset="${#match[1]}"
+      (( start_pos = end_pos + offset ))
+      (( end_pos = start_pos + $#arg ))
 
       # Compute the new $proc_buf. We advance it
       # (chop off characters from the beginning)

--- a/highlighters/main/test-data/empty-line.zsh
+++ b/highlighters/main/test-data/empty-line.zsh
@@ -1,0 +1,36 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2018 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+BUFFER=$'\\\n; ls'
+
+expected_region_highlight=(
+  '3 3 unknown-token' # ;
+  '5 6 command' # ls
+)


### PR DESCRIPTION
Fixes #347

I'm not a fan of `'3 3 unknown-token' # ;`, but I don't have a better idea without changing how `foo; ; bar` is highlighted.