### PR TITLE
Highlight named fd redirections

### DIFF
--- a/docs/highlighters/main.md
+++ b/docs/highlighters/main.md
@@ -58,6 +58,7 @@ This highlighter defines the following styles:
 * `assign` - parameter assignments (`x=foo` and `x=( )`)
 * `redirection` - redirection operators (`<`, `>`, etc)
 * `comment` - comments, when `setopt INTERACTIVE_COMMENTS` is in effect (`echo # foo`)
+* `named-fd` - named file descriptor (`echo foo {fd}>&2`)
 * `arg0` - a command word other than one of those enumerated above (other than a command, precommand, alias, function, or shell builtin command).
 * `default` - everything else
 

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -379,6 +379,8 @@ _zsh_highlight_main_highlighter_highlight_list()
   local -a match mbegin mend list_highlights
   # seen_alias is a map of aliases already seen to avoid loops like alias a=b b=a
   local -A seen_alias
+  # Pattern for parameter names
+  readonly parameter_name_pattern='([A-Za-z_][A-Za-z0-9_]*|[0-9]+)'
   list_highlights=()
 
   # "R" for round
@@ -561,7 +563,7 @@ _zsh_highlight_main_highlighter_highlight_list()
         _zsh_highlight_main_add_region_highlight $start_pos $end_pos redirection
       fi
       continue
-    elif [[ $arg == '{'*'}' ]] && _zsh_highlight_main__is_redirection $args[1]; then
+    elif [[ $arg == '{'${~parameter_name_pattern}'}' ]] && _zsh_highlight_main__is_redirection $args[1]; then
       # named file descriptor: {foo}>&2
       in_redirection=3
       _zsh_highlight_main_add_region_highlight $start_pos $end_pos named-fd
@@ -587,7 +589,7 @@ _zsh_highlight_main_highlighter_highlight_list()
         parameter_name=${arg:1}
       fi
       if [[ $res == none ]] && zmodload -e zsh/parameter &&
-         [[ ${parameter_name} =~ ^([A-Za-z_][A-Za-z0-9_]*|[0-9]+)$ ]] &&
+         [[ ${parameter_name} =~ ^${~parameter_name_pattern}$ ]] &&
          (( ${+parameters[(e)${MATCH}]} )) && [[ ${parameters[(e)$MATCH]} != *special* ]]
          then
         # Set $arg.

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -553,7 +553,7 @@ _zsh_highlight_main_highlighter_highlight_list()
 
     # Analyse the current word.
     if _zsh_highlight_main__is_redirection $arg ; then
-      if (( in_redirection && in_redirection != 2 )); then
+      if (( in_redirection == 1 )); then
         # The condition excludes the case that BUFFER='{foo}>&2' and we're on the '>&'.
         _zsh_highlight_main_add_region_highlight $start_pos $end_pos unknown-token
       else

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -58,6 +58,7 @@
 : ${ZSH_HIGHLIGHT_STYLES[assign]:=none}
 : ${ZSH_HIGHLIGHT_STYLES[redirection]:=none}
 : ${ZSH_HIGHLIGHT_STYLES[comment]:=fg=black,bold}
+: ${ZSH_HIGHLIGHT_STYLES[named-fd]:=none}
 : ${ZSH_HIGHLIGHT_STYLES[arg0]:=fg=green}
 
 # Whether the highlighter should be called or not.
@@ -552,12 +553,18 @@ _zsh_highlight_main_highlighter_highlight_list()
 
     # Analyse the current word.
     if _zsh_highlight_main__is_redirection $arg ; then
-      if (( in_redirection )); then
+      if (( in_redirection && in_redirection != 2 )); then
+        # The condition excludes the case that BUFFER='{foo}>&2' and we're on the '>&'.
         _zsh_highlight_main_add_region_highlight $start_pos $end_pos unknown-token
       else
         in_redirection=2
         _zsh_highlight_main_add_region_highlight $start_pos $end_pos redirection
       fi
+      continue
+    elif [[ $arg == '{'*'}' ]] && _zsh_highlight_main__is_redirection $args[1]; then
+      # named file descriptor: {foo}>&2
+      in_redirection=3
+      _zsh_highlight_main_add_region_highlight $start_pos $end_pos named-fd
       continue
     fi
 
@@ -864,7 +871,7 @@ _zsh_highlight_main_highlighter_highlight_list()
                  elif [[ $arg == $'\x5d' ]] && _zsh_highlight_main__stack_pop 'Q' builtin; then
                    :
                  else
-                   _zsh_highlight_main_highlighter_highlight_argument 1 $(( 1 - in_redirection ))
+                   _zsh_highlight_main_highlighter_highlight_argument 1 $(( 1 != in_redirection ))
                    continue
                  fi
                  ;;

--- a/highlighters/main/test-data/exec-redirection1.zsh
+++ b/highlighters/main/test-data/exec-redirection1.zsh
@@ -31,8 +31,8 @@ BUFFER='exec {foo}>&/tmp ls'
 
 expected_region_highlight=(
   "1 4 precommand" # exec
-  "6 10 redirection 'issue #238'" # {foo}
+  "6 10 named-fd" # {foo}
   "11 12 redirection" # >&
   "13 16 path" # /tmp
-  "18 19 command 'issue #238'" # ls
+  "18 19 command" # ls
 )


### PR DESCRIPTION
Inspired by #563 I looked through [the other `needs:lookahead` issues](https://github.com/zsh-users/zsh-syntax-highlighting/labels/needs%3Alookahead) and #238 seems to be a low hanging fruit.

Fixes #238.