### PR TITLE
Create various globals with typeset -g

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -28,7 +28,7 @@
 # -------------------------------------------------------------------------------------------------
 
 # First of all, ensure predictable parsing.
-zsh_highlight__aliases=`builtin alias -Lm '[^+]*'`
+typeset zsh_highlight__aliases="$(builtin alias -Lm '[^+]*')"
 # In zsh <= 5.2, `alias -L` emits aliases that begin with a plus sign ('alias -- +foo=42')
 # them without a '--' guard, so they don't round trip.
 #
@@ -57,9 +57,9 @@ fi
 # zsh-users/zsh@48cadf4 http://www.zsh.org/mla/workers//2017/msg00034.html
 autoload -Uz is-at-least
 if is-at-least 5.4; then
-  zsh_highlight__pat_static_bug=false
+  typeset -g zsh_highlight__pat_static_bug=false
 else
-  zsh_highlight__pat_static_bug=true
+  typeset -g zsh_highlight__pat_static_bug=true
 fi
 
 # Array declaring active highlighters names.


### PR DESCRIPTION
I decided recently that i'd turn on `warn_create_global`, but a lot of my `zshrc` stuff happens inside functions to avoid polluting my session with temp variables, and z-sy-h doesn't play entirely nice with that:

```
% zsh --warn-create-global -fc '() { source ./zsh-syntax-highlighting.zsh }'
./zsh-syntax-highlighting.zsh:31: scalar parameter zsh_highlight__aliases created globally in function (anon)
./zsh-syntax-highlighting.zsh:60: scalar parameter zsh_highlight__pat_static_bug created globally in function (anon)
```

Not sure if there are other places where this is an issue, but just changing those two seems to sort it for me.

Edit: Fixed the failing tests on old zsh, rebased