### PR TITLE
driver: ksharrays issue with $options

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -85,6 +85,8 @@ _zsh_highlight()
 
   # Before we 'emulate -L', save the user's options
   local -A zsyh_user_options
+  # Retain 1-indexing of zsh arrays
+  setopt localoptions noksharrays
   if zmodload -e zsh/parameter; then
     zsyh_user_options=("${(@kv)options}")
   else

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -91,7 +91,7 @@ _zsh_highlight()
     local canonical_options onoff option raw_options
     raw_options=(${(f)"$(emulate -R zsh; set -o)"})
     canonical_options=(${${${(M)raw_options:#*off}%% *}#no} ${${(M)raw_options:#*on}%% *})
-    for option in $canonical_options; do
+    for option in $("${(kv)options[@]}"); do
       [[ -o $option ]]
       # This variable cannot be eliminated c.f. workers/42101.
       onoff=${${=:-off on}[2-$?]}

--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -85,10 +85,8 @@ _zsh_highlight()
 
   # Before we 'emulate -L', save the user's options
   local -A zsyh_user_options
-  # Retain 1-indexing of zsh arrays
-  setopt localoptions noksharrays
   if zmodload -e zsh/parameter; then
-    zsyh_user_options=("${(@kv)options}")
+    zsyh_user_options=("${(kv)options[@]}")
   else
     local canonical_options onoff option raw_options
     raw_options=(${(f)"$(emulate -R zsh; set -o)"})


### PR DESCRIPTION
I personally use ksh-style arrays, but I noticed that this plugin doesn't work when that setting is enabled. Adding this one line of code allows this plugin to work for users who include "setopt ksharrays" in their .zshrc file.