### PR TITLE
adjust region end for vi command mode

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -157,24 +157,25 @@ _zsh_highlight()
     # Re-apply zle_highlight settings
 
     # region
-    if (( REGION_ACTIVE == 1 )); then
-      _zsh_highlight_apply_zle_highlight region standout "$MARK" "$CURSOR"
-    elif (( REGION_ACTIVE == 2 )); then
-      () {
+    () {
+      (( REGION_ACTIVE )) || return
+      integer min max
+      if (( MARK > CURSOR )) ; then
+	min=$CURSOR max=$MARK
+      else
+	min=$MARK max=$CURSOR
+      fi
+      if (( REGION_ACTIVE == 1 )); then
+	[[ $KEYMAP = vicmd ]] && (( max++ ))
+      elif (( REGION_ACTIVE == 2 )); then
         local needle=$'\n'
-        integer min max
-        if (( MARK > CURSOR )) ; then
-          min=$CURSOR max=$MARK
-        else
-          min=$MARK max=$CURSOR
-        fi
         # CURSOR and MARK are 0 indexed between letters like region_highlight
         # Do not include the newline in the highlight
         (( min = ${BUFFER[(Ib:min:)$needle]} ))
         (( max = ${BUFFER[(ib:max:)$needle]} - 1 ))
-        _zsh_highlight_apply_zle_highlight region standout "$min" "$max"
-      }
-    fi
+      fi
+      _zsh_highlight_apply_zle_highlight region standout "$min" "$max"
+    }
 
     # yank / paste (zsh-5.1.1 and newer)
     (( $+YANK_ACTIVE )) && (( YANK_ACTIVE )) && _zsh_highlight_apply_zle_highlight paste standout "$YANK_START" "$YANK_END"


### PR DESCRIPTION
This is a fix for issue #637.

You apparently need to replicate the logic from zle_refresh.c to redraw the region. This needs a slight fixup for vi command mode where in the C, we have:
```
        } else if (invicmdmode())
            INCPOS(region_highlights[0].end);
```
The shell code equivalent is essentially:
```
    [[ $KEYMAP = vicmd ]] && (( max++ ))
```
This adjustment roughly corresponds to the cursor adjustment you get when entering vi command mode. The change is slightly bigger because _zsh_highlight_apply_zle_highlight arguments don't have a fixed order so we need to swap them to get the max. You may want to do things differently, such as in that function directly.