### PR TITLE
'main': precommands += ssh-agent

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -321,6 +321,8 @@ _zsh_highlight_highlighter_main_paint()
     'catchsegv' ''
     'nohup' ''
     'setsid' :wc
+    # As of OpenSSH 8.1p1; -k is deliberately left out since it may not be followed by a command
+    'ssh-agent' aEPt:csDd
   )
 
   if [[ $zsyh_user_options[ignorebraces] == on || ${zsyh_user_options[ignoreclosebraces]:-off} == on ]]; then


### PR DESCRIPTION
This touches on the matters being discussed in #658, so not pushing it directly.  If unknown flags are to be highlighted as unknown-token, `k` should be added to the RHS; if they're to be highlighted as single-hyphen-option, it should be left out.

I suspect the specific case of `ssh-agent -k`, which may not be followed by further arguments, falls under "Hard cases make bad law" insofar as the design question in #658 is concerned.