### PR TITLE
WIP: Parse multi-word parameters in command position

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -78,8 +78,13 @@ _zsh_highlight_main_add_region_highlight() {
     return
   fi
   if (( in_param )); then
-    [[ $1 == unknown-token ]] && param_style=unknown-token
-    return
+    if [[ $1 == unknown-token ]]; then
+      param_style=unknown-token
+    fi
+    if [[ -n $param_style ]]; then
+      return
+    fi
+    param_style=$1
   fi
 
   # The calculation was relative to $buf but region_highlight is relative to $BUFFER.
@@ -951,8 +956,9 @@ _zsh_highlight_main_highlighter_highlight_list()
     fi
     _zsh_highlight_main_add_region_highlight $start_pos $end_pos $style
   done
+  : ${param_style:=$style}
   (( in_alias == 1 )) && in_alias=0 _zsh_highlight_main_add_region_highlight $start_pos $end_pos $alias_style
-  (( in_param == 1 )) && in_param=0 _zsh_highlight_main_add_region_highlight $start_pos $end_pos ${param_style:-unknown_token}
+  (( in_param == 1 )) && in_param=0 _zsh_highlight_main_add_region_highlight $start_pos $end_pos $param_style
   [[ "$proc_buf" = (#b)(#s)(([[:space:]]|\\$'\n')#) ]]
   REPLY=$(( end_pos + ${#match[1]} - 1 ))
   reply=($list_highlights)

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -488,6 +488,7 @@ _zsh_highlight_main_highlighter_highlight_list()
       if (( in_param == 0 )); then
         # start_pos and end_pos are of the alias (previous $arg) here
         _zsh_highlight_main_add_region_highlight $start_pos $end_pos ${param_style:-unknown_token}
+        param_style=""
       fi
     fi
 

--- a/highlighters/main/test-data/param-precommand-option-argument1.zsh
+++ b/highlighters/main/test-data/param-precommand-option-argument1.zsh
@@ -36,7 +36,7 @@ BUFFER='$sudo_u phy1729 echo foo'
 
 expected_region_highlight=(
   '1 7 precommand' # $sudo_u
-  '9 15 default "issue #674"' # phy1729
+  '9 15 default' # phy1729
   '18 20 command "issue #540"' # echo (not builtin)
   '22 24 default' # foo
 )

--- a/highlighters/main/test-data/param-precommand-option-argument3.zsh
+++ b/highlighters/main/test-data/param-precommand-option-argument3.zsh
@@ -36,7 +36,7 @@ BUFFER='$sudo_u phy1729 ls foo'
 
 expected_region_highlight=(
   '1 7 precommand' # sudo_u
-  '9 15 default "issue #674"' # phy1729
-  '17 18 command "issue #674"' # ls
+  '9 15 default' # phy1729
+  '17 18 command' # ls
   '20 22 default' # foo
 )

--- a/highlighters/main/test-data/parameter-value-contains-command-position1.zsh
+++ b/highlighters/main/test-data/parameter-value-contains-command-position1.zsh
@@ -1,0 +1,38 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2020 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+local foobar='x=$(ls)'
+
+BUFFER=$'$foobar'
+
+expected_region_highlight=(
+  # Used to highlight the "ba" as 'command' because the 'ls' showed through; issues #670 and #674
+  '1 7 assign' # $foobar
+)

--- a/highlighters/main/test-data/parameter-value-contains-command-position2.zsh
+++ b/highlighters/main/test-data/parameter-value-contains-command-position2.zsh
@@ -1,0 +1,38 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2020 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+local y='x=$(ls)'
+
+BUFFER=$'$y'
+
+expected_region_highlight=(
+  # Used to trigger a "BUG" message on stderr - issues #670 and #674
+  '1 2 assign' # $y
+)


### PR DESCRIPTION
Fixes #674. Improves the behaviour for #670: there's no longer a `BUG:` message on stderr, but the tests don't pass (the error is recorded in the log message).  Conflicts with #667.

The code is based on the aliases code.  Some edge cases are probably missing.

In particular, I think what's happening is that in aliases `alias_style` is initialized to `alias` but in parameters, `param_style` isn't analogously initialized, so that's why the `assign` style never gets set.  The `return` in `_zsh_highlight_main_add_region_highlight` makes `assign` not be recorded anywhere.

Hints welcome.