### PR TITLE
Attempt to fix #670

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -628,18 +628,24 @@ _zsh_highlight_main_highlighter_highlight_list()
          (( ${+parameters[(e)${MATCH}]} )) && [[ ${parameters[(e)$MATCH]} != *special* ]]
          then
         # Set $arg.
+        local -a words
+        local testarg
         case ${(tP)MATCH} in
           (*array*|*assoc*)
-            local -a words; words=( ${(P)MATCH} )
-            arg=${words[1]}
+            words=( ${(P)MATCH} )
+            testarg=${words[1]}
             ;;
           (*)
             # scalar, presumably
-            arg=${(P)MATCH}
+            words=( ${(zP)MATCH} )
+            testarg=${words[1]}
             ;;
         esac
-        _zsh_highlight_main__type "$arg" 0
-        res=$REPLY
+        _zsh_highlight_main__type "$testarg" 0
+        if [[ -n $REPLY ]] && [[ $REPLY != none ]]; then
+            res=$REPLY
+            arg=$testarg
+        fi
       fi
     }
 

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -645,6 +645,9 @@ _zsh_highlight_main_highlighter_highlight_list()
         if [[ -n $REPLY ]] && [[ $REPLY != none ]]; then
             res=$REPLY
             arg=$testarg
+        elif _zsh_highlight_main_highlighter_check_path $testarg; then
+            res=none
+            arg=$testarg
         fi
       fi
     }


### PR DESCRIPTION
Don't highlight parameters based on parameter expansion if the expansion type is
'none'.

As noted in the code comments, it's useful to highlight a parameter whose value happens to be a reserved word, command, etc. as the value would be highlighted.  However, if the type is "none", then there's not enough information to highlight the argument, so just highlight the un-expanded parameter.