### PR TITLE
Fix highlighting of multiline aliases

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -85,6 +85,10 @@
   `_zsh_highlight_main__precmd_hook:1: array parameter _zsh_highlight_main__command_type_cache set in enclosing scope in function _zsh_highlight_main__precmd_hook`
   [#727, #731, #732, #733]
 
+- Fix highlighting of alias whose definitions use a simple command terminator
+  (such as `;`, `|`, `&&`) before a newline
+  [#677; had regressed in 0.7.0]
+
 # Changes in version 0.7.1
 
 - Remove out-of-date information from the 0.7.0 changelog.
@@ -159,6 +163,7 @@ Known issues include:
   before a newline will incorrectly be highlighted as an error.  See issue #677
   for examples and workarounds.
   [#677]
+  [UPDATE: Fixed in 0.8.0]
 
 
 # Changes in version 0.6.0

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -854,9 +854,17 @@ _zsh_highlight_main_highlighter_highlight_list()
         style=commandseparator
       elif [[ $this_word == *':start:'* ]] && [[ $arg == $'\n' ]]; then
         style=commandseparator
+      elif [[ $this_word == *':start:'* ]] && [[ $arg == ';' ]] && (( in_alias )); then
+        style=commandseparator 
       else
-        # This highlights empty commands (semicolon follows nothing) as an error.
-        # Zsh accepts them, though.
+        # Empty commands (semicolon follows nothing) are valid syntax.
+        # However, in interactive use they are likely to be erroneous;
+        # therefore, we highlight them as errors.
+        #
+        # Alias definitions are exempted from this check to allow multiline aliases
+        # with explicit (redundant) semicolons: «alias foo=$'bar;\nbaz'» (issue #677).
+        #
+        # See also #691 about possibly changing the style used here. 
         style=unknown-token
       fi
 

--- a/highlighters/main/test-data/alias-comment1.zsh
+++ b/highlighters/main/test-data/alias-comment1.zsh
@@ -33,5 +33,5 @@ alias x=$'# foo\npwd'
 BUFFER='x'
 
 expected_region_highlight=(
-  '1 1 alias "issue #677"' # x
+  '1 1 alias' # x
 )


### PR DESCRIPTION
Exempt such aliases from the empty commands sanity check.

Does anyone see a downside to making this change?  The argument is basically that it's not z-sy-h's job to lint the user's dotfiles, but I wonder if there's a counter-argument that I'm overlooking.

Fixes #677, which knowingly regressed in 0.7.0 compared to 0.6.0..

This didn't require converting `';'` back to `$'\n'` in alias expansions after all.

@itchyny Please test/review.