### PR TITLE
WIP: Highlight history modifiers (#485)

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -1282,10 +1282,11 @@ _zsh_highlight_main_highlighter_highlight_double_quote()
            ;;
       '$' ) style=dollar-double-quoted-argument
             # Look for an alphanumeric parameter name.
-            if [[ ${arg:$i} =~ ^([A-Za-z_][A-Za-z0-9_]*|[0-9]+) ]] ; then
+            local alphanumeric_parameter_name='[A-Za-z_][A-Za-z0-9_]*|[0-9]+'
+            if [[ ${arg:$i} =~ ^(${alphanumeric_parameter_name}) ]] ; then
               (( k += $#MATCH )) # highlight the parameter name
               (( i += $#MATCH )) # skip past it
-            elif [[ ${arg:$i} =~ ^[{]([A-Za-z_][A-Za-z0-9_]*|[0-9]+)[}] ]] ; then
+            elif [[ ${arg:$i} =~ ^[{](${alphanumeric_parameter_name})[}] ]] ; then
               (( k += $#MATCH )) # highlight the parameter name and braces
               (( i += $#MATCH )) # skip past it
             elif [[ $arg[i+1] == '$' ]]; then

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -1283,10 +1283,12 @@ _zsh_highlight_main_highlighter_highlight_double_quote()
       '$' ) style=dollar-double-quoted-argument
             # Look for an alphanumeric parameter name.
             local alphanumeric_parameter_name='[A-Za-z_][A-Za-z0-9_]*|[0-9]+'
-            if [[ ${arg:$i} =~ ^(${alphanumeric_parameter_name}) ]] ; then
+            # :gs,:s,:F,:W take an argument between delimiters; we don't currently highlight delimiters.
+            local history_modifiers=':[aAcehlpPqQ&tuxfw]|:gs.|:s.|:F.|:W.'
+            if [[ ${arg:$i} =~ ^(${alphanumeric_parameter_name})(${history_modifiers})* ]] ; then
               (( k += $#MATCH )) # highlight the parameter name
               (( i += $#MATCH )) # skip past it
-            elif [[ ${arg:$i} =~ ^[{](${alphanumeric_parameter_name})[}] ]] ; then
+            elif [[ ${arg:$i} =~ ^[{](${alphanumeric_parameter_name})(${history_modifiers})*[}] ]] ; then
               (( k += $#MATCH )) # highlight the parameter name and braces
               (( i += $#MATCH )) # skip past it
             elif [[ $arg[i+1] == '$' ]]; then

--- a/highlighters/main/test-data/double-quoted5-history-modifiers.zsh
+++ b/highlighters/main/test-data/double-quoted5-history-modifiers.zsh
@@ -1,0 +1,46 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2018 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+BUFFER=$': "$foo: ${foo}: $foo:X ${foo:X} $foo:h ${foo:h} $foo:h:h ${foo:h:h} $foo:hey ${foo}:h"'
+
+expected_region_highlight=(
+  '1 1 builtin' # :
+  '3 87 default' # "$foo: ${foo}: $foo:X ${foo:X} $foo:h ${foo:h} $foo:h:h ${foo:h:h} $foo:hey ${foo}:h"
+  '3 87 double-quoted-argument' # "$foo: ${foo}: $foo:X ${foo:X} $foo:h ${foo:h} $foo:h:h ${foo:h:h} $foo:hey ${foo}:h"
+  '4 7 dollar-double-quoted-argument' # $foo
+  '10 15 dollar-double-quoted-argument' # ${foo}
+  '18 21 dollar-double-quoted-argument' # $foo
+  '34 39 dollar-double-quoted-argument' # $foo:h
+  '41 48 dollar-double-quoted-argument' # ${foo:h}
+  '50 57 dollar-double-quoted-argument' # $foo:h:h
+  '59 68 dollar-double-quoted-argument' # ${foo:h:h}
+  '70 75 dollar-double-quoted-argument' # $foo:h - without the following "ey"
+  '79 84 dollar-double-quoted-argument' # ${foo}
+)


### PR DESCRIPTION
This is https://github.com/zsh-users/zsh-syntax-highlighting/issues/485#issuecomment-359181850, rebased and with the tests written (for reasons explained there).

Concerns:

- [ ] https://github.com/zsh-users/zsh-syntax-highlighting/issues/485#issuecomment-358833116 "Modifiers require braces when KSH_ARRAYS is set."
- [ ] https://github.com/zsh-users/zsh-syntax-highlighting/issues/485#issuecomment-358833831 Modifiers with arguments
- [ ] The `:t2`/`:h2` modifier (new since #485) - https://github.com/zsh-users/zsh/blob/e5765bfdc89f131d03051ba4963819fdfe252503/README#L49-L63
- [ ] https://github.com/zsh-users/zsh-syntax-highlighting/issues/485#issuecomment-359221286 @phy1729 requested that "[some unknown referent] and the parameter handling in _highlight_arguments should be pulled out into a new function" — @phy1729, do you by chance recall what the words "that bit" referred to?