### PR TITLE
Avoid warning under setopt warn_nested_var

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -1677,7 +1677,7 @@ _zsh_highlight_main_highlighter_expand_path()
 # -------------------------------------------------------------------------------------------------
 
 _zsh_highlight_main__precmd_hook() {
-  _zsh_highlight_main__command_type_cache=()
+  typeset -gA _zsh_highlight_main__command_type_cache=()
 }
 
 autoload -Uz add-zsh-hook


### PR DESCRIPTION
Previously in a shell running with `setopt warn_nested_var`, the
following warning would be produced:
> ```
> _zsh_highlight_main__precmd_hook:1: array parameter _zsh_highlight_main__command_type_cache set in enclosing scope in function _zsh_highlight_main__precmd_hook
> ```

The documentation for `WARN_NESTED_VAR` is:
> Print a warning message when an existing parameter from an enclosing function scope, or  global, is set  in a function by an assignment or in  math context. […] Where possible, use of `typeset -g` to set the parameter suppresses the error, but note that this needs to be used every time the parameter is  set.