### PR TITLE
Optimize the unquoted arguments characterwise walker

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -1311,7 +1311,12 @@ _zsh_highlight_main_highlighter_highlight_argument()
       fi
   esac
 
+  # This loop is a hot path.  Keep it fast!
   for (( ; i <= $#arg ; i += 1 )); do
+    if [[ $arg[$i] != [\\\'\"\`\$\<\>\*\?] ]]; then
+      continue
+    fi
+
     case "$arg[$i]" in
       "\\") (( i += 1 )); continue;;
       "'")

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -1312,12 +1312,11 @@ _zsh_highlight_main_highlighter_highlight_argument()
   esac
 
   # This loop is a hot path.  Keep it fast!
-  for (( ; i <= $#arg ; i += 1 )); do
-    if [[ $arg[$i] != [\\\'\"\`\$\<\>\*\?] ]]; then
-      continue
-    fi
-
+  (( --i ))
+  while (( ++i <= $#arg )); do
+    i=${arg[(ib.i.)[\\\'\"\`\$\<\>\*\?]]}
     case "$arg[$i]" in
+      "") break;;
       "\\") (( i += 1 )); continue;;
       "'")
         _zsh_highlight_main_highlighter_highlight_single_quote $i

--- a/tests/test-zprof.zsh
+++ b/tests/test-zprof.zsh
@@ -74,12 +74,4 @@ run_test() {
   }
 }
 
-# Process each test data file in test data directory.
-local data_file
-TIMEFMT="%*Es"
-{ time (for data_file in ${0:h:h}/highlighters/$1/test-data/cthulhu.zsh; do
-  run_test "$data_file"
-  (( $pipestatus[1] )) && exit 2
-done) } 2>&1 || exit $?
-
-exit 0
+run_test

--- a/tests/test-zprof.zsh
+++ b/tests/test-zprof.zsh
@@ -1,0 +1,85 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2010-2015 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+# Load the main script.
+. ${0:h:h}/zsh-syntax-highlighting.zsh
+
+# Activate the highlighter.
+ZSH_HIGHLIGHT_HIGHLIGHTERS=(main)
+
+source_file=0.7.1:highlighters/$1/$1-highlighter.zsh
+
+# Runs a highlighting test
+# $1: data file
+run_test_internal() {
+  setopt interactivecomments
+
+  local -a highlight_zone
+
+  local tests_tempdir="$1"; shift
+  local srcdir="$PWD"
+  builtin cd -q -- "$tests_tempdir" || { echo >&2 "Bail out! cd failed: $?"; return 1 }
+
+  # Load the data and prepare checking it.
+  PREBUFFER=
+  BUFFER=$(cd -- "$srcdir" && git cat-file blob $source_file)
+  expected_region_highlight=()
+
+  zmodload zsh/zprof
+  zprof -c
+  # Set $? for _zsh_highlight
+  true && _zsh_highlight
+  zprof
+}
+
+run_test() {
+  # Do not combine the declaration and initialization: «local x="$(false)"» does not set $?.
+  local __tests_tempdir
+  __tests_tempdir="$(mktemp -d)" && [[ -d $__tests_tempdir ]] || {
+    echo >&2 "Bail out! mktemp failed"; return 1
+  }
+  typeset -r __tests_tempdir # don't allow tests to override the variable that we will 'rm -rf' later on
+
+  {
+    (run_test_internal "$__tests_tempdir" "$@")
+  } always {
+    rm -rf -- "$__tests_tempdir"
+  }
+}
+
+# Process each test data file in test data directory.
+local data_file
+TIMEFMT="%*Es"
+{ time (for data_file in ${0:h:h}/highlighters/$1/test-data/cthulhu.zsh; do
+  run_test "$data_file"
+  (( $pipestatus[1] )) && exit 2
+done) } 2>&1 || exit $?
+
+exit 0


### PR DESCRIPTION
See the log messages for details.  tl;dr, running the `main` highlighter on its own 0.7.1 tag:

- 23% faster with interactivecomments on
- 50% faster with interactivecomments off

And if on top of that the same optimization is applied to the double-quoted highlighter, performance drops by 3% (relative to the 23% faster state).