### PR TITLE
Add comments for the platform dependency of the regex module

### DIFF
--- a/docs/highlighters/regexp.md
+++ b/docs/highlighters/regexp.md
@@ -15,12 +15,13 @@ typeset -A ZSH_HIGHLIGHT_REGEXP
 ZSH_HIGHLIGHT_REGEXP+=('^rm .*' fg="red",bold)
 ```
 
-This will highlight the whole line starting with `rm` (for all operating systems, 
-in contrast to the below example).
+This will highlight the whole line starting with `rm` command (for all
+operating systems, in contrast to the below example).
 
-Some regex patterns are [subject to the host platform][MAN_ZSH_REGEX], especially
-the kernel. To highlight `sudo` only as a complete word, i.e., `sudo cmd`, but 
-not `sudoedit`:
+Some regular expressions are [subject to the host platform][MAN_ZSH_REGEX], 
+especially the kernel. To highlight `sudo` only as a complete word, i.e., 
+`sudo cmd`, but not `sudoedit`, the respective regular expressions for the host
+systems would be:
 
 * GNU-Linux
 

--- a/docs/highlighters/regexp.md
+++ b/docs/highlighters/regexp.md
@@ -10,37 +10,35 @@ patterns.
 To use this highlighter, associate regular expressions with styles in the
 `ZSH_HIGHLIGHT_REGEXP` associative array, for example in `~/.zshrc`:
 
-```zsh
-typeset -A ZSH_HIGHLIGHT_REGEXP
-ZSH_HIGHLIGHT_REGEXP+=('\bsudo\b' fg=123,bold)
-```
+* GNU-Linux
 
-This will highlight "sudo" only as a complete word, i.e., "sudo cmd", but not
-"sudoedit"
+  ```zsh
+  typeset -A ZSH_HIGHLIGHT_REGEXP
+  ZSH_HIGHLIGHT_REGEXP+=('\<sudo\>' fg=123,bold)
+  ```
+
+* BSD-based platforms
+
+  ```zsh
+  typeset -A ZSH_HIGHLIGHT_REGEXP
+  ZSH_HIGHLIGHT_REGEXP+=('[[:<:]]sudo[[:>:]]' fg=123,bold)
+  ```
+
+This will highlight "sudo" only as a complete word, i.e., "sudo cmd", but not "sudoedit".
+
+As in the example, some regex patterns are platform-dependent. Refer to the 
+manual page of `re_format` before applying regular expressions to avoid confusing 
+results. If portability matters, using only [POSIX ERE (extended regular 
+expressions)][POSIX_ERE] could be an option.
 
 The syntax for values is the same as the syntax of "types of highlighting" of
 the zsh builtin `$zle_highlight` array, which is documented in [the `zshzle(1)`
 manual page][zshzle-Character-Highlighting].
 
 See also: [regular expressions tutorial][perlretut], zsh regexp operator `=~`
-in [the `zshmisc(1)` manual page][zshmisc-Conditional-Expressions]
+in [the `zshmisc(1)` manual page][zshmisc-Conditional-Expressions], GNU
 
+[POSIX_ERE]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_04
 [zshzle-Character-Highlighting]: http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting
 [perlretut]: http://perldoc.perl.org/perlretut.html
 [zshmisc-Conditional-Expressions]: http://zsh.sourceforge.net/Doc/Release/Conditional-Expressions.html#Conditional-Expressions
-
-### Cautions to BSD-based platform users
-
-In BSD-based platform such as macOS, the regex metacharacters with leading backslash (`\`)
-such as `\b`, `\w`, etc. are [not supported](https://stackoverflow.com/a/12696899).
-
-So if you want something like the above example, you should use `[[:<:]]`(matches the beginning of a word)
-with `[[:>:]]`(matches the end of a word). The complete example would be like:
-
-```zsh
-typeset -A ZSH_HIGHLIGHT_REGEXP
-ZSH_HIGHLIGHT_REGEXP+=('[[:<:]]sudo[[:>:]]' fg=123,bold)
-```
-
-For other metacharacters, consider using
-[POSIX ERE](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_04) instead.

--- a/docs/highlighters/regexp.md
+++ b/docs/highlighters/regexp.md
@@ -23,7 +23,7 @@ especially the `libc` module. To highlight `sudo` only as a complete word, i.e.,
 `sudo cmd`, but not `sudoedit`, the respective regular expressions for the host
 systems would be:
 
-* Platforms with GNU `libc` (e.g., many GNU/Linux)
+* Platforms with GNU `libc` (e.g., many GNU/Linux distributions)
 
   ```zsh
   typeset -A ZSH_HIGHLIGHT_REGEXP

--- a/docs/highlighters/regexp.md
+++ b/docs/highlighters/regexp.md
@@ -23,7 +23,7 @@ especially the `libc` module. To highlight `sudo` only as a complete word, i.e.,
 `sudo cmd`, but not `sudoedit`, the respective regular expressions for the host
 systems would be:
 
-* Platform with GNU libc (e.g., many GNU/Linux)
+* Platforms with GNU `libc` (e.g., many GNU/Linux)
 
   ```zsh
   typeset -A ZSH_HIGHLIGHT_REGEXP

--- a/docs/highlighters/regexp.md
+++ b/docs/highlighters/regexp.md
@@ -12,25 +12,25 @@ To use this highlighter, associate regular expressions with styles in the
 
 ```zsh
 typeset -A ZSH_HIGHLIGHT_REGEXP
-ZSH_HIGHLIGHT_REGEXP+=('^rm .*' fg="red",bold)
+ZSH_HIGHLIGHT_REGEXP+=('^rm .*' fg=red,bold)
 ```
 
 This will highlight the whole line starting with `rm` command (for all
 operating systems, in contrast to the below example).
 
 Some regular expressions are [subject to the host platform][MAN_ZSH_REGEX], 
-especially the kernel. To highlight `sudo` only as a complete word, i.e., 
+especially the `libc` module. To highlight `sudo` only as a complete word, i.e., 
 `sudo cmd`, but not `sudoedit`, the respective regular expressions for the host
 systems would be:
 
-* GNU-Linux
+* Platform with GNU libc (e.g., many GNU/Linux)
 
   ```zsh
   typeset -A ZSH_HIGHLIGHT_REGEXP
   ZSH_HIGHLIGHT_REGEXP+=('\<sudo\>' fg=123,bold)
   ```
 
-* BSD-based platforms
+* BSD-based platforms (e.g., macOS)
 
   ```zsh
   typeset -A ZSH_HIGHLIGHT_REGEXP

--- a/docs/highlighters/regexp.md
+++ b/docs/highlighters/regexp.md
@@ -10,6 +10,18 @@ patterns.
 To use this highlighter, associate regular expressions with styles in the
 `ZSH_HIGHLIGHT_REGEXP` associative array, for example in `~/.zshrc`:
 
+```zsh
+typeset -A ZSH_HIGHLIGHT_REGEXP
+ZSH_HIGHLIGHT_REGEXP+=('^rm .*' fg="red",bold)
+```
+
+This will highlight the whole line starting with `rm` (for all operating systems, 
+in contrast to the below example).
+
+Some regex patterns are [subject to the host platform][MAN_ZSH_REGEX], especially
+the kernel. To highlight `sudo` only as a complete word, i.e., `sudo cmd`, but 
+not `sudoedit`:
+
 * GNU-Linux
 
   ```zsh
@@ -24,12 +36,7 @@ To use this highlighter, associate regular expressions with styles in the
   ZSH_HIGHLIGHT_REGEXP+=('[[:<:]]sudo[[:>:]]' fg=123,bold)
   ```
 
-This will highlight "sudo" only as a complete word, i.e., "sudo cmd", but not "sudoedit".
-
-As in the example, some regex patterns are platform-dependent. Refer to the 
-manual page of `re_format` before applying regular expressions to avoid confusing 
-results. If portability matters, using only [POSIX ERE (extended regular 
-expressions)][POSIX_ERE] could be an option.
+Both would give the same results, but do not work on each other's system.
 
 The syntax for values is the same as the syntax of "types of highlighting" of
 the zsh builtin `$zle_highlight` array, which is documented in [the `zshzle(1)`
@@ -38,7 +45,7 @@ manual page][zshzle-Character-Highlighting].
 See also: [regular expressions tutorial][perlretut], zsh regexp operator `=~`
 in [the `zshmisc(1)` manual page][zshmisc-Conditional-Expressions]
 
-[POSIX_ERE]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_04
+[MAN_ZSH_REGEX]: http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fregex-Module
 [zshzle-Character-Highlighting]: http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting
 [perlretut]: http://perldoc.perl.org/perlretut.html
 [zshmisc-Conditional-Expressions]: http://zsh.sourceforge.net/Doc/Release/Conditional-Expressions.html#Conditional-Expressions

--- a/docs/highlighters/regexp.md
+++ b/docs/highlighters/regexp.md
@@ -11,7 +11,7 @@ To use this highlighter, associate regular expressions with styles in the
 `ZSH_HIGHLIGHT_REGEXP` associative array, for example in `~/.zshrc`:
 
 ```zsh
-typeset -A ZSH_HIGHLIGHT_PATTERNS
+typeset -A ZSH_HIGHLIGHT_REGEXP
 ZSH_HIGHLIGHT_REGEXP+=('\bsudo\b' fg=123,bold)
 ```
 
@@ -28,3 +28,19 @@ in [the `zshmisc(1)` manual page][zshmisc-Conditional-Expressions]
 [zshzle-Character-Highlighting]: http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting
 [perlretut]: http://perldoc.perl.org/perlretut.html
 [zshmisc-Conditional-Expressions]: http://zsh.sourceforge.net/Doc/Release/Conditional-Expressions.html#Conditional-Expressions
+
+### Cautions to BSD-based platform users
+
+In BSD-based platform such as macOS, the regex metacharacters with leading backslash (`\`)
+such as `\b`, `\w`, etc. are [not supported](https://stackoverflow.com/a/12696899).
+
+So if you want something like the above example, you should use `[[:<:]]`(matches the beginning of a word)
+with `[[:>:]]`(matches the end of a word). The complete example would be like:
+
+```zsh
+typeset -A ZSH_HIGHLIGHT_REGEXP
+ZSH_HIGHLIGHT_REGEXP+=('[[:<:]]sudo[[:>:]]' fg=123,bold)
+```
+
+For other metacharacters, consider using
+[POSIX ERE](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_04) instead.

--- a/docs/highlighters/regexp.md
+++ b/docs/highlighters/regexp.md
@@ -36,7 +36,7 @@ the zsh builtin `$zle_highlight` array, which is documented in [the `zshzle(1)`
 manual page][zshzle-Character-Highlighting].
 
 See also: [regular expressions tutorial][perlretut], zsh regexp operator `=~`
-in [the `zshmisc(1)` manual page][zshmisc-Conditional-Expressions], GNU
+in [the `zshmisc(1)` manual page][zshmisc-Conditional-Expressions]
 
 [POSIX_ERE]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_04
 [zshzle-Character-Highlighting]: http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting


### PR DESCRIPTION
In BSD-based platform such as macOS, the metacharacters with leading "\\" are not supported.
This adds comments for users with those OS, to avoid confusing results.

Also changes the wrong associative array name in the example(s).