### PR TITLE
Bug fix: infinite loop when the current working directory doesn't exist

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -1211,14 +1211,18 @@ _zsh_highlight_main_highlighter_check_path()
   if [[ $expanded_path[1] == / ]]; then
     tmp_path=$expanded_path
   else
-    tmp_path=$PWD/$expanded_path
+    # Unlike $PWD, ${(%):-%/} predictably expands to '.' if the current
+    # working directory doesn't exist.
+    tmp_path=${(%):-%/}/$expanded_path
   fi
   tmp_path=$tmp_path:a
 
-  while [[ $tmp_path != / ]]; do
-    [[ -n ${(M)ZSH_HIGHLIGHT_DIRS_BLACKLIST:#$tmp_path} ]] && return 1
-    tmp_path=$tmp_path:h
-  done
+  if [[ $tmp_path == /* ]]; then
+    while [[ $tmp_path != / ]]; do
+      [[ -n ${(M)ZSH_HIGHLIGHT_DIRS_BLACKLIST:#$tmp_path} ]] && return 1
+      tmp_path=$tmp_path:h
+    done
+  fi
 
   if (( in_command_position )); then
     if [[ -x $expanded_path ]]; then


### PR DESCRIPTION
To reproduce:

```zsh
mkdir /tmp/foo
cd /tmp/foo
rmdir /tmp/foo
exec zsh -f
source ~/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
```

Press <kbd>a</kbd> and zle will hang.