### PR TITLE
Don't highlight backslash-escaped brackets

### DIFF
--- a/highlighters/brackets/test-data/escaped-brackets.zsh
+++ b/highlighters/brackets/test-data/escaped-brackets.zsh
@@ -1,0 +1,48 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2020 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+ZSH_HIGHLIGHT_STYLES[bracket-level-1]=
+ZSH_HIGHLIGHT_STYLES[bracket-level-2]=
+ZSH_HIGHLIGHT_STYLES[bracket-level-3]=
+# expect no matchingbracket highlight
+ZSH_HIGHLIGHT_STYLES[cursor-matchingbracket]=
+
+CURSOR=9 # cursor is zero-based
+
+BUFFER='if [[ "\]" =~ "[\)\}\]]" ]]; then echo true; fi'
+
+expected_region_highlight=(
+  '23 23 bracket-level-3' # ]
+   '4  4 bracket-level-1' # [
+   '5  5 bracket-level-2' # [
+  '26 26 bracket-level-2' # ]
+  '27 27 bracket-level-1' # ]
+  '16 16 bracket-level-3' # [
+)


### PR DESCRIPTION
I've looked at #532, #533, #455, and am not entirely sure of your current thinking on this.

This PR addresses only backslash escaping.  Current highlighting:
![last image](https://user-images.githubusercontent.com/727482/98450617-0446b900-210c-11eb-9d55-d2726d6d2173.png)

with patch:
<img alt="Screen Shot 2020-11-07 at 2 49 28 PM" src="https://user-images.githubusercontent.com/727482/98450628-1e809700-210c-11eb-9131-a84ee45a6bfd.png">

~Let me know if this is agreeable, and if so I will figure out how to add a test.~  Nice setup — `tests/generate.zsh` is easy.

This coding choice is idiosyncratic:
```zsh
if (( escaped_state )); then
  :
```
but if this PR is accepted it will make a cleaner diff with my next one.