### PR TITLE
Add cursor-containing-brackets highlighting

### DIFF
--- a/highlighters/brackets/brackets-highlighter.zsh
+++ b/highlighters/brackets/brackets-highlighter.zsh
@@ -36,6 +36,7 @@
 : ${ZSH_HIGHLIGHT_STYLES[bracket-level-4]:=fg=yellow,bold}
 : ${ZSH_HIGHLIGHT_STYLES[bracket-level-5]:=fg=cyan,bold}
 : ${ZSH_HIGHLIGHT_STYLES[cursor-matchingbracket]:=standout}
+: ${ZSH_HIGHLIGHT_STYLES[cursor-containing-brackets]:=}
 
 # Whether the brackets highlighter should be called or not.
 _zsh_highlight_highlighter_brackets_predicate()
@@ -48,7 +49,7 @@ _zsh_highlight_highlighter_brackets_paint()
 {
   local char style
   local -i bracket_color_size=${#ZSH_HIGHLIGHT_STYLES[(I)bracket-level-*]} buflen=${#BUFFER} escaped_state level=0 matchingpos pos
-  local -A levelpos lastoflevel matching
+  local -A containing levelpos lastoflevel matching
 
   # Find all brackets and remember which one is matching
   pos=0
@@ -57,29 +58,37 @@ _zsh_highlight_highlighter_brackets_paint()
     (( ++pos ))
     if [[ $char = "\\" ]]; then
       (( escaped_state = !escaped_state ))
+      containing[$pos]=$containing[$(( pos - 1 ))]
       continue
     fi
     case $char in
       ["([{"])
-        if (( ! escaped_state )); then
+        if (( escaped_state )); then
+          containing[$pos]=$containing[$(( pos - 1 ))]
+        else
           levelpos[$pos]=$((++level))
           lastoflevel[$level]=$pos
+          containing[$pos]=$pos
         fi
         ;;
       [")]}"])
         if (( escaped_state )); then
-          :
+          containing[$pos]=$containing[$(( pos - 1 ))]
         elif (( level > 0 )); then
           matchingpos=$lastoflevel[$level]
           levelpos[$pos]=$((level--))
           if _zsh_highlight_brackets_match $matchingpos $pos; then
             matching[$matchingpos]=$pos
             matching[$pos]=$matchingpos
+            containing[$pos]=containing[$(( matchingpos - 1))]
           fi
         else
           levelpos[$pos]=-1
+          containing[$pos]=$containing[$(( pos - 1 ))]
         fi
         ;;
+      *)
+        containing[$pos]=$containing[$(( pos - 1 ))]
     esac
     escaped_state=0
   done
@@ -95,12 +104,24 @@ _zsh_highlight_highlighter_brackets_paint()
     fi
   done
 
-  # If cursor is on a bracket, then highlight corresponding bracket, if any.
   if [[ $WIDGET != zle-line-finish ]]; then
+    # If cursor is on a bracket, then highlight corresponding bracket, if any.
     pos=$((CURSOR + 1))
     if (( $+levelpos[$pos] )) && (( $+matching[$pos] )); then
       local -i otherpos=$matching[$pos]
       _zsh_highlight_add_highlight $((otherpos - 1)) $otherpos cursor-matchingbracket
+    fi
+    if [[ -n $ZSH_HIGHLIGHT_STYLES[cursor-containing-brackets] ]]; then
+      # If cursor is inside a balanced pair, highlight the pair
+      pos=$CURSOR
+      if (( containing[$pos] > 0 )); then
+        local -i opener=$containing[$pos]
+        local -i closer=$matching[$opener]
+        if (( closer )); then
+          _zsh_highlight_add_highlight $((opener - 1)) $opener cursor-containing-brackets
+          _zsh_highlight_add_highlight $((closer - 1)) $closer cursor-containing-brackets
+        fi
+      fi
     fi
   fi
 }

--- a/highlighters/brackets/test-data/escaped-brackets.zsh
+++ b/highlighters/brackets/test-data/escaped-brackets.zsh
@@ -1,0 +1,48 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2020 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+ZSH_HIGHLIGHT_STYLES[bracket-level-1]=
+ZSH_HIGHLIGHT_STYLES[bracket-level-2]=
+ZSH_HIGHLIGHT_STYLES[bracket-level-3]=
+# expect no matchingbracket highlight
+ZSH_HIGHLIGHT_STYLES[cursor-matchingbracket]=
+
+CURSOR=9 # cursor is zero-based
+
+BUFFER='if [[ "\]" =~ "[\)\}\]]" ]]; then echo true; fi'
+
+expected_region_highlight=(
+  '23 23 bracket-level-3' # ]
+   '4  4 bracket-level-1' # [
+   '5  5 bracket-level-2' # [
+  '26 26 bracket-level-2' # ]
+  '27 27 bracket-level-1' # ]
+  '16 16 bracket-level-3' # [
+)


### PR DESCRIPTION
After #777 another proposal is `ZSH_HIGHLIGHT_STYLES[cursor-containing-brackets]`, a dynamic style like `cursor-matchingbracket`, which changes with the context of the cursor.

I left it unstyled by default in the PR.  If enabled as `fg=red`, with other bracket highlighting turned off, it works like this, revealing whichever balanced brackets currently contain the point:
![containing_bracket_style](https://user-images.githubusercontent.com/727482/98737637-79b4c280-2374-11eb-8108-84ae0726b1cd.gif)

This PR currently includes the commit in #777, but I can rebase that problem away later.

No tests yet, just starting a discussion.  I personally find this highlighting extremely valuable.  Multiple levels could also be highlighted, like `bracket-level-N`.