### PR TITLE
Add bracket-error-open and bracket-error-close bracket highlighting styles

### DIFF
--- a/highlighters/brackets/brackets-highlighter.zsh
+++ b/highlighters/brackets/brackets-highlighter.zsh
@@ -30,6 +30,8 @@
 
 # Define default styles.
 : ${ZSH_HIGHLIGHT_STYLES[bracket-error]:=fg=red,bold}
+: ${ZSH_HIGHLIGHT_STYLES[bracket-error-open]:=}
+: ${ZSH_HIGHLIGHT_STYLES[bracket-error-close]:=}
 : ${ZSH_HIGHLIGHT_STYLES[bracket-level-1]:=fg=blue,bold}
 : ${ZSH_HIGHLIGHT_STYLES[bracket-level-2]:=fg=green,bold}
 : ${ZSH_HIGHLIGHT_STYLES[bracket-level-3]:=fg=magenta,bold}
@@ -80,6 +82,12 @@ _zsh_highlight_highlighter_brackets_paint()
       if (( bracket_color_size )); then
         _zsh_highlight_add_highlight $((pos - 1)) $pos bracket-level-$(( (levelpos[$pos] - 1) % bracket_color_size + 1 ))
       fi
+    elif [[ -n $ZSH_HIGHLIGHT_STYLES[bracket-error-open] ]] && \
+        [[ ${BUFFER[$pos]} = '[' || ${BUFFER[$pos]} = '(' || ${BUFFER[$pos]} = '{' ]]; then
+      _zsh_highlight_add_highlight $((pos - 1)) $pos bracket-error-open
+    elif [[ -n $ZSH_HIGHLIGHT_STYLES[bracket-error-close] ]] && \
+        [[ ${BUFFER[$pos]} = ']' || ${BUFFER[$pos]} = ')' || ${BUFFER[$pos]} = '}' ]]; then
+      _zsh_highlight_add_highlight $((pos - 1)) $pos bracket-error-close
     else
       _zsh_highlight_add_highlight $((pos - 1)) $pos bracket-error
     fi

--- a/highlighters/brackets/test-data/mismatch-parentheses-2.zsh
+++ b/highlighters/brackets/test-data/mismatch-parentheses-2.zsh
@@ -1,0 +1,42 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2020 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+ZSH_HIGHLIGHT_STYLES[bracket-error-open]=default
+ZSH_HIGHLIGHT_STYLES[bracket-error-close]=default
+ZSH_HIGHLIGHT_STYLES[bracket-level-1]=
+ZSH_HIGHLIGHT_STYLES[bracket-level-2]=
+
+BUFFER='echo ({x}}'
+
+expected_region_highlight=(
+  "6  6  bracket-error-open"  # (
+  "7  7  bracket-level-2"     # {
+  "9  9  bracket-level-2"     # }
+  "10 10 bracket-error-close" # ]
+)


### PR DESCRIPTION
Rationale:

Typing at the command-line generally proceeds from left to right, and the typist may open many brackets as he goes.  Newly-opened brackets usually not errors, but unfinished thoughts.  The user may therefore wish to style open-bracket match-failures differently than close-bracket match-failures.

I prefer to color only the close-bracket match-failure as an error:
```
ZSH_HIGHLIGHT_STYLES[bracket-error-open]=default
ZSH_HIGHLIGHT_STYLES[bracket-error-close]='fg=red'
```

This code actually could be written to fall through to `bracket-error` instead of having a distinct `bracket-error-close` style, but that asymmetry might confuse the user.