### PR TITLE
main: Fix alias loops in nested lists (e.g. command substitution)

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -421,6 +421,11 @@ _zsh_highlight_highlighter_main_paint()
     unset X_ZSH_HIGHLIGHT_DIRS_BLACKLIST
   fi
 
+  # seen_alias is a map of aliases already seen to avoid loops like alias a=b b=a
+  #     must be local above _highlight_list for cases where _highlight_list is reentered
+  #     e.g. alias ls='echo $(ls)'
+  local -A seen_alias
+
   _zsh_highlight_main_highlighter_highlight_list -$#PREBUFFER '' 1 "$PREBUFFER$BUFFER"
 
   # end is a reserved word
@@ -510,8 +515,6 @@ _zsh_highlight_main_highlighter_highlight_list()
   # in_param is analogous for parameter expansions
   integer in_param=0 len=$#buf
   local -a in_alias match mbegin mend list_highlights
-  # seen_alias is a map of aliases already seen to avoid loops like alias a=b b=a
-  local -A seen_alias
   # Pattern for parameter names
   readonly parameter_name_pattern='([A-Za-z_][A-Za-z0-9_]*|[0-9]+)'
   list_highlights=()

--- a/highlighters/main/test-data/alias-loop-commandsubstitution.zsh
+++ b/highlighters/main/test-data/alias-loop-commandsubstitution.zsh
@@ -1,0 +1,37 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2021 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+alias ls='echo "$(ls)"'
+
+BUFFER='ls'
+
+expected_region_highlight=(
+  '1 2 alias' # ls
+)


### PR DESCRIPTION
`alias ls='echo $(ls)'` then `ls` will cause zsh to crash. This avoids that.

The idea is that we are still in the alias even when recursing into a nested list like a command substitution, so _highlight_list is the wrong place to local seen_alias.