### PR TITLE
Fixed broken fish shell link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ zsh-syntax-highlighting [![Build Status][build-status-image]][build-status]
 
 *Requirements: zsh 4.3.11+.*
 
-[fish]: http://www.fishshell.com/
+[fish]: https://fishshell.com/
 [zsh]: http://www.zsh.org/
 
 This package provides syntax highlighting for the shell zsh.  It enables


### PR DESCRIPTION
The correct link should be https://fishshell.com/