### PR TITLE
skip command line parsing when there are still keys in the input queue

### DIFF
--- a/zsh-syntax-highlighting.zsh
+++ b/zsh-syntax-highlighting.zsh
@@ -219,7 +219,8 @@ _zsh_highlight()
   [[ -n ${ZSH_HIGHLIGHT_MAXLENGTH:-} ]] && [[ $#BUFFER -gt $ZSH_HIGHLIGHT_MAXLENGTH ]] && return $ret
 
   # Do not highlight if there are pending inputs (copy/paste).
-  [[ $PENDING -gt 0 ]] && return $ret
+  (( KEYS_QUEUED_COUNT > 0 )) && return $ret
+  (( PENDING > 0 )) && return $ret
 
   {
     local cache_place


### PR DESCRIPTION
If you are working with paths that are on a slow filesystem (eg, NFS shares), then highlighting can become sluggish at times. 

`ZSH_HIGHLIGHT_DIRS_BLACKLIST+=(/some/path /and/more/paths)` does work but there is still somewhere a small slow down, I couldn't find where exactly it becomes slower when it has to handle paths from a slow filesystem compared to a fast filesystem. 

The slow down is so small that you dont notice a problem while typing. But when you paste in a 60-character path, it blocks for a while, because in that case it looks like 60 key events to zsh and it causes a highlighter pass everytime. The "small slow down times 60" is then very apparent.

One solution might be to skip parsing when there is still data in the input queue (see `KEYS_QUEUED_COUNT` in a zsh zle widget). That's typically the case with pasting. Skipping parsing seems okay to me in that case since you know you will get called immediately again because there are more keys to be processed.

Maybe this can be useful, or an approach inspired by it. It doesnt have to be this exact commit.