### PR TITLE
Added `regexp` to the list of built-in highlighters in documentation

### DIFF
--- a/docs/highlighters.md
+++ b/docs/highlighters.md
@@ -6,6 +6,7 @@ Syntax highlighting is done by pluggable highlighters:
 * `main` - the base highlighter, and the only one [active by default][main].
 * `brackets` - [matches brackets][brackets] and parenthesis.
 * `pattern` - matches [user-defined patterns][pattern].
+* `regexp` - matches [user-defined regular expressions][regexp].
 * `cursor` - matches [the cursor position][cursor].
 * `root` - highlights the whole command line [if the current user is root][root].
 * `line` - applied to [the whole command line][line].
@@ -13,6 +14,7 @@ Syntax highlighting is done by pluggable highlighters:
 [main]: highlighters/main.md
 [brackets]: highlighters/brackets.md
 [pattern]: highlighters/pattern.md
+[regexp]: highlighters/regexp.md
 [cursor]: highlighters/cursor.md
 [root]: highlighters/root.md
 [line]: highlighters/line.md

--- a/docs/highlighters.md
+++ b/docs/highlighters.md
@@ -3,19 +3,19 @@ zsh-syntax-highlighting / highlighters
 
 Syntax highlighting is done by pluggable highlighters:
 
-* `main` - the base highlighter, and the only one [active by default][1].
-* `brackets` - [matches brackets][2] and parenthesis.
-* `pattern` - matches [user-defined patterns][3].
-* `cursor` - matches [the cursor position][4].
-* `root` - highlights the whole command line [if the current user is root][5].
-* `line` - applied to [the whole command line][6].
+* `main` - the base highlighter, and the only one [active by default][main].
+* `brackets` - [matches brackets][brackets] and parenthesis.
+* `pattern` - matches [user-defined patterns][pattern].
+* `cursor` - matches [the cursor position][cursor].
+* `root` - highlights the whole command line [if the current user is root][root].
+* `line` - applied to [the whole command line][line].
 
-[1]: highlighters/main.md
-[2]: highlighters/brackets.md
-[3]: highlighters/pattern.md
-[4]: highlighters/cursor.md
-[5]: highlighters/root.md
-[6]: highlighters/line.md
+[main]: highlighters/main.md
+[brackets]: highlighters/brackets.md
+[pattern]: highlighters/pattern.md
+[cursor]: highlighters/cursor.md
+[root]: highlighters/root.md
+[line]: highlighters/line.md
 
 
 Highlighter-independent settings


### PR DESCRIPTION
Added the link to the `regexp` highlighter documentation file and specified that the `pattern` highlighter uses globbing to make the difference between the two explicit.