### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -75,7 +75,7 @@ This list is incomplete as there are too many
 Add `antigen bundle zsh-users/zsh-syntax-highlighting` as the last bundle in
 your `.zshrc`.
 
-### [Fig](https://fig.io)
+#### [Fig](https://fig.io)
 
 Fig adds apps, shortcuts, and autocomplete to your existing terminal.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -75,6 +75,14 @@ This list is incomplete as there are too many
 Add `antigen bundle zsh-users/zsh-syntax-highlighting` as the last bundle in
 your `.zshrc`.
 
+### [Fig](https://fig.io)
+
+Fig adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install Zsh Syntax Highlighting in just one click.
+
+<a href="https://fig.io/plugins/other/zsh-syntax-highlighting" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 #### [Oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
 
 1. Clone this repository in oh-my-zsh's plugins directory:


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

Zsh Syntax Highlighting is already listed in the store so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!