### PR TITLE
Fix proxychains args

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -363,7 +363,7 @@ _zsh_highlight_highlighter_main_paint()
     'env' u:i
     'ionice' cn:t:pPu # util-linux 2.33.1-0.1
     'strace' IbeaosXPpEuOS:ACdfhikqrtTvVxyDc # strace 4.26-0.2
-    'proxychains' q:f # proxychains 4.4.0
+    'proxychains' f:q # proxychains 4.4.0
     'torsocks' idq:upaP # Torsocks 2.3.0
     'torify' idq:upaP # Torsocks 2.3.0
     'ssh-agent' aEPt:csDd:k # As of OpenSSH 8.1p1


### PR DESCRIPTION
Args for proxychains should be f:q => -f file  : -q quiet.

From comments in the same function:
``` 
# $precommand_options maps precommand name to values of $flags_with_argument, 
# $flags_sans_argument, and flags_solo for that precommand, joined by a 
# colon. 
```