### PR TITLE
fix comments being invisible in certain conditions

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -59,7 +59,7 @@
 : ${ZSH_HIGHLIGHT_STYLES[back-dollar-quoted-argument]:=fg=cyan}
 : ${ZSH_HIGHLIGHT_STYLES[assign]:=none}
 : ${ZSH_HIGHLIGHT_STYLES[redirection]:=fg=yellow}
-: ${ZSH_HIGHLIGHT_STYLES[comment]:=fg=black,bold}
+: ${ZSH_HIGHLIGHT_STYLES[comment]:=fg=black,bg=magenta,bold}
 : ${ZSH_HIGHLIGHT_STYLES[named-fd]:=none}
 : ${ZSH_HIGHLIGHT_STYLES[numeric-fd]:=none}
 : ${ZSH_HIGHLIGHT_STYLES[arg0]:=fg=green}


### PR DESCRIPTION
When `setopt interactivecomments` is set, comments become invisible in a black terminal. This commit fixes it by adding a magenta background.

Of course the choice of colour is debatable, I went with what made the most sense to me.

`fg=black` could also be removed entirely, so that the text is in the same colours as the default text.

Fixes #510 