### PR TITLE
docs: ZSH_HIGHLIGHT_HIGHLIGHTERS is (main) by default

### DIFF
--- a/docs/highlighters.md
+++ b/docs/highlighters.md
@@ -40,15 +40,13 @@ ZSH_HIGHLIGHT_MAXLENGTH=512
 How to activate highlighters
 ----------------------------
 
-To activate an highlighter, add it to the `ZSH_HIGHLIGHT_HIGHLIGHTERS` array in
-`~/.zshrc`, for example:
+To activate an highlighter, add it to the `ZSH_HIGHLIGHT_HIGHLIGHTERS` array.
+By default `ZSH_HIGHLIGHT_HIGHLIGHTERS` is `(main)`. For example to activate
+`brackets`, `pattern`, and `cursor` highlighters, in `~/.zshrc` do:
 
 ```zsh
-ZSH_HIGHLIGHT_HIGHLIGHTERS=(main brackets pattern cursor)
+ZSH_HIGHLIGHT_HIGHLIGHTERS+=(brackets pattern cursor)
 ```
-
-By default, `$ZSH_HIGHLIGHT_HIGHLIGHTERS` is unset and only the `main`
-highlighter is active.
 
 
 How to tweak highlighters


### PR DESCRIPTION
1. Fix: Current docs say "By default, `$ZSH_HIGHLIGHT_HIGHLIGHTERS` is unset". By default
    ```shell
    % echo ${(t)ZSH_HIGHLIGHT_HIGHLIGHTERS}
    array
    % echo $ZSH_HIGHLIGHT_HIGHLIGHTERS
    main
    ```
2. Subjective: Current docs say that to "add [a highlighter] to the `ZSH_HIGHLIGHT_HIGHLIGHTERS` array", do
    ```shell
    ZSH_HIGHLIGHT_HIGHLIGHTERS=(main <highlighter>)
    ```
    which to me reads as "redefined", compared to `+=(<highlighter)` for "add"