### PR TITLE
main: Add highlighting for hashed directories with autocd and cdablevars

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -1215,6 +1215,12 @@ _zsh_highlight_main_highlighter_check_path()
     integer autocd=0
   fi
 
+  if [[ $zsyh_user_options[cdablevars] == on ]]; then
+    integer cdablevars=1
+  else
+    integer cdablevars=0
+  fi
+
   if (( in_command_position )); then
     # ### Currently, this value is never returned: either it's overwritten
     # ### below, or the return code is non-zero
@@ -1254,6 +1260,9 @@ _zsh_highlight_main_highlighter_check_path()
         # ### This seems unreachable for the current callers
         return 0
       fi
+    elif (( autocd && cdablevars && $+nameddirs[(e)$expanded_path] )) && [[ -x $nameddirs[$expanded_path] ]]; then
+      REPLY=hashed-command
+      return 0
     fi
   else
     if [[ -L $expanded_path || -e $expanded_path ]]; then

--- a/highlighters/main/test-data/hashed-directory-1.zsh
+++ b/highlighters/main/test-data/hashed-directory-1.zsh
@@ -1,0 +1,40 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2023 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+setopt autocd
+setopt cdablevars
+mkdir -p foo
+mkdir -p foo/bar
+hash -d bar=foo/bar
+BUFFER=$'bar'
+
+expected_region_highlight=(
+  '1 3 hashed-command'
+)

--- a/highlighters/main/test-data/hashed-directory-2.zsh
+++ b/highlighters/main/test-data/hashed-directory-2.zsh
@@ -1,0 +1,38 @@
+#!/usr/bin/env zsh
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2023 zsh-syntax-highlighting contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the zsh-syntax-highlighting contributors nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------------------------------
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# -------------------------------------------------------------------------------------------------
+
+setopt autocd
+setopt cdablevars
+hash -d bar=/nonexistent
+BUFFER=$'bar'
+
+expected_region_highlight=(
+  '1 3 unknown-token'
+)


### PR DESCRIPTION
See #930 (or at least just https://github.com/zsh-users/zsh-syntax-highlighting/issues/930#issuecomment-1590633859).

What this PR does:
* If a hashed directory `foo` exists and the path it resolves to also exists, it will highlight it as a `hashed-command`
![image](https://github.com/zsh-users/zsh-syntax-highlighting/assets/5954994/412376f2-fad8-419f-9ac0-4224b50b427e)

What this PR does not do:
* Does not highlight after further Tab-complete expansion of the hashed directory, even though it should be valid
![image](https://github.com/zsh-users/zsh-syntax-highlighting/assets/5954994/a5cb1ba1-6470-49c5-97f7-9046dcb1d3a0)
![image](https://github.com/zsh-users/zsh-syntax-highlighting/assets/5954994/ab1112b6-286b-4ea1-be09-12176de9645e)

If this feels like enough to be a PR on its own, then you could merge. If it feels incomplete, but on the right path, someone else could offer guidance and I'll see if I can complete it or they could pick it up themselves, or if it's completely wrong then it could just be closed.