### PR TITLE
updated Arch linux install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,6 +42,11 @@ Second, enable zsh-syntax-highlighting by sourcing the script. Running this comm
     echo "source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" >> ${ZDOTDIR:-$HOME}/.zshrc
     ```
 
+* Arch Linux:
+    ```zsh
+    echo "source /usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" >> ${ZDOTDIR:-$HOME}/.zshrc
+    ```
+
 * NetBSD and OpenBSD:
 
     ```zsh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,6 +65,8 @@ Then restart zsh (such as by opening a new instance of your terminal emulator).
 
 * On most Linux distributions (except perhaps NixOS):
 `source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh`
+* Arch Linux:
+`source /usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh`
 * NetBSD and OpenBSD:
 `source /usr/local/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh`
 


### PR DESCRIPTION
When I tried to install this package the command `echo "source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" >> ${ZDOTDIR:-$HOME}/.zshrc` (present on the INSTALL.md file) didn't work since the file doesn't exist. The actual file is located on `/usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh`
The only machine I have runs Arch Linux, and since I didn't want to assume that this is the case for most linux distributions I decided to just add the corresponding install instruction to the INSTALL.md file.