### PR TITLE
docs: Remove Fig instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -107,12 +107,6 @@ This list is incomplete as there are too many
 Add `antigen bundle zsh-users/zsh-syntax-highlighting` as the last bundle in
 your `.zshrc`.
 
-#### [Fig](https://fig.io)
-
-Click the `Install Plugin` button on the [Fig plugin page][fig-plugin].
-
-[fig-plugin]: https://fig.io/plugins/other/zsh-syntax-highlighting
-
 #### [Oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
 
 1. Clone this repository in oh-my-zsh's plugins directory:


### PR DESCRIPTION
This project is dead. https://fig.io/blog/post/fig-is-sunsetting

Effectively it's a revert of https://github.com/zsh-users/zsh-syntax-highlighting/commit/b2c910a85ed84cb7e5108e7cb3406a2e825a858f. 