### PR TITLE
Docs: Remove Bloat in the Plain Install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,13 +71,17 @@ Simply clone this repository and source the script:
 
 ```zsh
 git clone https://github.com/zsh-users/zsh-syntax-highlighting.git
+```
+
+Optional:
+```zsh
 echo "source ${(q-)PWD}/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" >> ${ZDOTDIR:-$HOME}/.zshrc
 ```
 
   Then, enable syntax highlighting in the current interactive shell:
 
 ```zsh
-source ./zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+source ~/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 ```
 
   If `git` is not installed, download and extract a snapshot of the latest


### PR DESCRIPTION
Hello,
The way you install the plugin on a plain .zshrc is quite simple, these are just some changes to debloat the .zshrc

The first change is to replace ./zsh-syntax-highlighting/zsh-syntax-highlighting.zsh with ~/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh

This is due to the fact that with ./ , zsh was looking inside the current folder which would often introduce bloat as the folders outside of home were stored and if I were to go into a different folder and open a new terminal tab, well then that folder all of the sudden has the plugin folder wasting disk space.

With ~/ , it fixes that issue because it tells zsh to look in the home folder and then to go into the plugin directory, this has less bloat because if I am in another folder, it doesn't make a folder for the plugin there as now it doesn't have to as zsh now knows it is in the home directory.

The other change is to the echo command after git clone, I put optional there because if you plain install it, you don't need that command and it ends up being bloat. The reason I added the Optional tag is because it might be needed for a specific plugin manager even though the section is titled: In your .zshrc.