### PR TITLE
main: Add systemd run0 equivalent to sudo

### DIFF
--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -354,6 +354,7 @@ _zsh_highlight_highlighter_main_paint()
     'pkexec' '' # doesn't take short options; immune to #121 because it's usually not passed --option flags
     # Not listed: -h, which has two different meanings.
     'sudo' Cgprtu:AEHPSbilns:eKkVv # as of sudo 1.8.21p2
+    'run0' ugD:h # systemd 256.6
     'stdbuf' ioe:
     'eatmydata' ''
     'catchsegv' ''


### PR DESCRIPTION
~I suspect these changes are incorrect or incomplete.
Is the second value a list of single letter flags arguments? Should it be `Cgprtu:AEHPSbilns:eKkVv`?~
[`run0`](https://www.freedesktop.org/software/systemd/man/devel/run0.html) is a systemd 256 alternative to `sudo`.