### PR TITLE
Update Homebrew package link for zsh-syntax-highlighting

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ First, install the package:
 
 [arch-package]: https://www.archlinux.org/packages/zsh-syntax-highlighting
 [AUR-package]: https://aur.archlinux.org/packages/zsh-syntax-highlighting-git
-[brew-package]: https://github.com/Homebrew/homebrew-core/blob/master/Formula/z/zsh-syntax-highlighting.rb
+[brew-package]: https://formulae.brew.sh/formula/zsh-syntax-highlighting
 [debian-package]: https://packages.debian.org/zsh-syntax-highlighting
 [fedora-package]: https://apps.fedoraproject.org/packages/zsh-syntax-highlighting
 [fedora-package-alt]: https://bodhi.fedoraproject.org/updates/?packages=zsh-syntax-highlighting


### PR DESCRIPTION
Rather link to install instructions than to source code. I just wanted to give this plugin a try and was confused by the link that send me to the source code of the formula. I think https://formulae.brew.sh/formula/zsh-syntax-highlighting is more helpful for installing it.