### PR TITLE
main: support styling paths based on glob matches

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@
   [#942]
 - Highlight redirection targets as paths if possible [#982].
 
+## Highlight paths with matching patterns
+
+When matchers start with `*.`, the are treated as globs to further refine thee
+highlighting of paths [#982].
 
 # Changes in 0.8.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 
 - Highlight `&>` `>&|` `>&!` `&>|` and `&>!` as redirection.
   [#942]
+- Highlight redirection targets as paths if possible [#982].
 
 
 # Changes in 0.8.0

--- a/docs/highlighters/main.md
+++ b/docs/highlighters/main.md
@@ -67,6 +67,11 @@ This highlighter defines the following styles:
 * `arg0` - a command word other than one of those enumerated above (other than a command, precommand, alias, function, or shell builtin command).
 * `default` - everything else
 
+Additionally, styles starting with `*.` may be used to style `path` and
+`redirection` argument matches with a more specific style. For example,
+defining the `*.png` style will apply to any `path` or `redirection` target
+ending with `.png`.
+
 To override one of those styles, change its entry in `ZSH_HIGHLIGHT_STYLES`,
 for example in `~/.zshrc`:
 

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -1441,6 +1441,9 @@ _zsh_highlight_main_highlighter_highlight_argument()
     if (( in_redirection )) && [[ $last_arg == *['<>']['&'] && $arg[$1,-1] == (<0->|p|-) ]]; then
       if [[ $arg[$1,-1] == (p|-) ]]; then
         base_style=redirection
+        if _zsh_highlight_main_highlighter_check_path $arg[$1,-1] 0; then
+          base_style=$REPLY
+        fi
       else
         base_style=numeric-fd
       fi

--- a/highlighters/main/main-highlighter.zsh
+++ b/highlighters/main/main-highlighter.zsh
@@ -1258,6 +1258,16 @@ _zsh_highlight_main_highlighter_check_path()
     fi
   else
     if [[ -L $expanded_path || -e $expanded_path ]]; then
+      for key in ${(k)ZSH_HIGHLIGHT_STYLES}; do
+        case $key in
+          "*."*) ;;
+          *) continue ;;
+        esac
+        case $arg in
+          *.$key[3,-1]) REPLY=$key ;;
+        esac
+      done
+
       return 0
     fi
   fi


### PR DESCRIPTION
---
Addresses #605 in that it is supported. Actually transforming `LS_COLORS` (or `CLICOLOR` or `dircolors -b` output) into the appropriate style mapping is left as an exercise for the user.

Also likely obsoletes #680.

Still needs tests ~~and changelog updated to reference the allocated ID for this PR~~.